### PR TITLE
ci: build pr previews with hash routing

### DIFF
--- a/.github/workflows/deploy-dev-preview.yaml
+++ b/.github/workflows/deploy-dev-preview.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Build
         if: github.event.action != 'closed'
-        run: VITE_BASE_URL="/pr-${{ github.event.number }}" pnpm build
+        run: VITE_ROUTER=hash VITE_BASE_URL="/pr-${{ github.event.number }}" pnpm build
 
       - name: Deploy PR preview
         uses: rossjrw/pr-preview-action@v1


### PR DESCRIPTION
This means that we can refresh the PR preview page even if we are on any subroute.