### PR TITLE
fix: distinct dot colors for onboarding setup lists

### DIFF
--- a/src/routes/(onboarding)/finances/edit/investments/+page.svelte
+++ b/src/routes/(onboarding)/finances/edit/investments/+page.svelte
@@ -134,11 +134,11 @@
   </div>
 
   <div class="flex w-full flex-col gap-4">
-    {#each investments as investment (investment.id)}
+    {#each investments as investment, idx (investment.id)}
       <EditableItemCard
         item={investment}
         collapsedValue={formatBalance(investment.balance)}
-        dotColor={CATEGORY_COLORS.investments[0]}
+        dotColor={CATEGORY_COLORS.investments[idx % CATEGORY_COLORS.investments.length]}
         onToggleEditing={() => {
           investment.editing = !investment.editing
         }}

--- a/src/routes/(onboarding)/finances/edit/liabilities/+page.svelte
+++ b/src/routes/(onboarding)/finances/edit/liabilities/+page.svelte
@@ -153,11 +153,11 @@
   </div>
 
   <div class="flex w-full flex-col gap-4">
-    {#each liabilities as liability (liability.id)}
+    {#each liabilities as liability, idx (liability.id)}
       <EditableItemCard
         item={liability}
         collapsedValue={formatBalance(liability.outstanding_balance)}
-        dotColor={CATEGORY_COLORS.liabilities[0]}
+        dotColor={CATEGORY_COLORS.liabilities[idx % CATEGORY_COLORS.liabilities.length]}
         onToggleEditing={() => {
           liability.editing = !liability.editing
         }}

--- a/src/routes/(onboarding)/finances/edit/tangible-assets/+page.svelte
+++ b/src/routes/(onboarding)/finances/edit/tangible-assets/+page.svelte
@@ -168,11 +168,11 @@
   </div>
 
   <div class="flex w-full flex-col gap-4">
-    {#each assets as asset (asset.id)}
+    {#each assets as asset, idx (asset.id)}
       <EditableItemCard
         item={asset}
         collapsedValue={formatValue(asset.value)}
-        dotColor={CATEGORY_COLORS.tangibleAssets[0]}
+        dotColor={CATEGORY_COLORS.tangibleAssets[idx % CATEGORY_COLORS.tangibleAssets.length]}
         onToggleEditing={() => {
           asset.editing = !asset.editing
         }}


### PR DESCRIPTION
## What changed

The onboarding setup lists (investments, liabilities, tangible assets) hardcoded the dot color to index `[0]` of `CATEGORY_COLORS`, so every item in a category rendered the same color. Each `{#each}` loop now exposes `idx` and the dot color cycles with `CATEGORY_COLORS.<cat>[idx % CATEGORY_COLORS.<cat>.length]`.

## Why

Distinct items in a category should get distinct colors, as they already do on the financial-data overview pages. This brings the setup pages in line with that established pattern.

## Files

- `src/routes/(onboarding)/finances/edit/investments/+page.svelte`
- `src/routes/(onboarding)/finances/edit/liabilities/+page.svelte`
- `src/routes/(onboarding)/finances/edit/tangible-assets/+page.svelte`

Fixes #78

## Notes for reviewer

This worktree has no `node_modules` installed, so `pnpm check`/lint and a live preview couldn't be run locally — CI will need to validate. The change is a one-line replication of the already-passing overview pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)