### PR TITLE
fix: persist add-plan Details & Data steps across back navigation (#76)

### DIFF
--- a/src/lib/plan-draft.test.ts
+++ b/src/lib/plan-draft.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  type PlanDraftDetails,
+  buildPlanCreationFields,
+  clearPlanDraft,
+  getPlanEndDate,
+  getPlanStartDate,
+  loadPlanDraft,
+  savePlanDraft,
+} from './plan-draft'
+
+function makeDetails(overrides: Partial<PlanDraftDetails> = {}): PlanDraftDetails {
+  return {
+    name: 'My plan',
+    notes: 'some notes',
+    startType: 'at_specific_date',
+    startYear: '2030',
+    startMonth: '5', // June (0-indexed)
+    endType: 'at_specific_date',
+    endAge: undefined,
+    endYear: '2050',
+    endMonth: '0', // January
+    currency: 'CZK',
+    inflation: 2,
+    ...overrides,
+  }
+}
+
+describe('getPlanStartDate', () => {
+  it('uses the first of the selected year/month for a specific start date', () => {
+    expect(getPlanStartDate(makeDetails())).toBe('2030-06-01')
+  })
+
+  it('uses the first of the current month when starting now', () => {
+    const now = new Date()
+    const expected = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-01`
+    expect(getPlanStartDate(makeDetails({ startType: 'now' }))).toBe(expected)
+  })
+})
+
+describe('getPlanEndDate', () => {
+  it('derives the end date from birth date + age when ending by age', () => {
+    const details = makeDetails({ endType: 'when_age_is', endAge: 85 })
+    const birthDate = new Date(1990, 2, 15) // March 1990
+    // 1990 + 85 = 2075, month preserved (March, 0-indexed 2), first of month
+    expect(getPlanEndDate(details, birthDate)).toBe('2075-03-01')
+  })
+
+  it('falls back to start year + age when birth date is unknown', () => {
+    const details = makeDetails({
+      startType: 'at_specific_date',
+      startYear: '2030',
+      endType: 'when_age_is',
+      endAge: 85,
+    })
+    expect(getPlanEndDate(details, undefined)).toBe('2115-01-01')
+  })
+
+  it('uses the selected year/month for a specific end date', () => {
+    expect(getPlanEndDate(makeDetails(), undefined)).toBe('2050-01-01')
+  })
+})
+
+describe('plan draft persistence', () => {
+  beforeEach(() => {
+    const store = new Map<string, string>()
+    vi.stubGlobal('sessionStorage', {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => store.set(k, v),
+      removeItem: (k: string) => store.delete(k),
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns an empty draft when nothing is stored', () => {
+    expect(loadPlanDraft()).toEqual({})
+  })
+
+  it('round-trips a saved draft', () => {
+    const details = makeDetails()
+    savePlanDraft({ details })
+    expect(loadPlanDraft()).toEqual({ details })
+  })
+
+  it('preserves the other step when each step saves independently', () => {
+    const details = makeDetails()
+    const data = {
+      includeCash: true,
+      includeInvestments: false,
+      includeTangibleAssets: true,
+      includeLiabilities: true,
+      includeIncomes: true,
+      includeExpenses: true,
+      selectedInvestmentIds: ['a', 'b'],
+      selectedTangibleAssetIds: [],
+      selectedLiabilityIds: [],
+      selectedIncomeIds: [],
+      selectedExpenseIds: [],
+    }
+    // Details step saves first, then Data step merges in its selections.
+    savePlanDraft({ ...loadPlanDraft(), details })
+    savePlanDraft({ ...loadPlanDraft(), data })
+    expect(loadPlanDraft()).toEqual({ details, data })
+  })
+
+  it('clears the draft', () => {
+    savePlanDraft({ details: makeDetails() })
+    clearPlanDraft()
+    expect(loadPlanDraft()).toEqual({})
+  })
+
+  it('recovers from a corrupt draft', () => {
+    sessionStorage.setItem('kalkul-plan-draft', '{not json')
+    expect(loadPlanDraft()).toEqual({})
+  })
+})
+
+describe('buildPlanCreationFields', () => {
+  it('trims the name, drops empty notes, and converts inflation to a rate', () => {
+    const details = makeDetails({ name: '  Spaced  ', notes: '   ', inflation: 3 })
+    const fields = buildPlanCreationFields(details, undefined)
+    expect(fields.name).toBe('Spaced')
+    expect(fields.notes).toBeUndefined()
+    expect(fields.inflation_rate).toBe(0.03)
+    expect(fields.currency).toBe('CZK')
+    expect(fields.start_date).toBe('2030-06-01')
+    expect(fields.end_date).toBe('2050-01-01')
+  })
+
+  it('defaults inflation to 2% when undefined', () => {
+    const fields = buildPlanCreationFields(makeDetails({ inflation: undefined }), undefined)
+    expect(fields.inflation_rate).toBe(0.02)
+  })
+})

--- a/src/lib/plan-draft.ts
+++ b/src/lib/plan-draft.ts
@@ -1,0 +1,110 @@
+import { formatDate } from '$lib/@snaha/kalkul-maths'
+import type { PlanEndType, PlanStartType } from '$lib/schemas'
+
+const STORAGE_KEY = 'kalkul-plan-draft'
+
+/** Raw form state of the add-plan "Details" step, persisted so the step can be re-hydrated. */
+export interface PlanDraftDetails {
+  name: string
+  notes: string
+  startType: PlanStartType
+  startYear: string
+  startMonth: string
+  endType: PlanEndType
+  endAge: number | undefined
+  endYear: string
+  endMonth: string
+  currency: string
+  inflation: number | undefined
+}
+
+/** Selections of the add-plan "Data" step, persisted so the step can be re-hydrated. */
+export interface PlanDraftData {
+  includeCash: boolean
+  includeInvestments: boolean
+  includeTangibleAssets: boolean
+  includeLiabilities: boolean
+  includeIncomes: boolean
+  includeExpenses: boolean
+  selectedInvestmentIds: string[]
+  selectedTangibleAssetIds: string[]
+  selectedLiabilityIds: string[]
+  selectedIncomeIds: string[]
+  selectedExpenseIds: string[]
+}
+
+/** The full add-plan draft kept in sessionStorage across the multi-step flow. */
+export interface PlanDraft {
+  details?: PlanDraftDetails
+  data?: PlanDraftData
+}
+
+/** Values derived from the draft that are needed to create the portfolio. */
+export interface PlanCreationFields {
+  name: string
+  notes: string | undefined
+  currency: string
+  start_date: string
+  end_date: string
+  inflation_rate: number
+}
+
+/** Load the current draft from sessionStorage, returning an empty draft if none/invalid. */
+export function loadPlanDraft(): PlanDraft {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY)
+    return raw ? (JSON.parse(raw) as PlanDraft) : {}
+  } catch {
+    return {}
+  }
+}
+
+export function savePlanDraft(draft: PlanDraft): void {
+  sessionStorage.setItem(STORAGE_KEY, JSON.stringify(draft))
+}
+
+export function clearPlanDraft(): void {
+  sessionStorage.removeItem(STORAGE_KEY)
+}
+
+/** Compute the plan start date from the raw "Details" form state. */
+export function getPlanStartDate(details: PlanDraftDetails): string {
+  if (details.startType === 'now') {
+    const now = new Date()
+    return formatDate(new Date(now.getFullYear(), now.getMonth(), 1))
+  }
+  return formatDate(new Date(Number(details.startYear), Number(details.startMonth), 1))
+}
+
+/** Compute the plan end date from the raw "Details" form state and the user's birth date. */
+export function getPlanEndDate(details: PlanDraftDetails, birthDate: Date | undefined): string {
+  if (details.endType === 'when_age_is' && details.endAge !== undefined) {
+    if (birthDate) {
+      return formatDate(new Date(birthDate.getFullYear() + details.endAge, birthDate.getMonth(), 1))
+    }
+    // Fallback: use start year + age
+    const startYearNum =
+      details.startType === 'now' ? new Date().getFullYear() : Number(details.startYear)
+    return formatDate(new Date(startYearNum + details.endAge, 0, 1))
+  }
+  if (details.endYear && details.endMonth !== '') {
+    return formatDate(new Date(Number(details.endYear), Number(details.endMonth), 1))
+  }
+  // Fallback (unreachable due to canContinue validation)
+  return formatDate(new Date(new Date().getFullYear() + 30, 0, 1))
+}
+
+/** Build the portfolio-creation fields from the draft's "Details" state. */
+export function buildPlanCreationFields(
+  details: PlanDraftDetails,
+  birthDate: Date | undefined,
+): PlanCreationFields {
+  return {
+    name: details.name.trim(),
+    notes: details.notes.trim() || undefined,
+    currency: details.currency,
+    start_date: getPlanStartDate(details),
+    end_date: getPlanEndDate(details, birthDate),
+    inflation_rate: (details.inflation ?? 2) / 100,
+  }
+}

--- a/src/routes/(add-plan)/plan/add/data/+page.svelte
+++ b/src/routes/(add-plan)/plan/add/data/+page.svelte
@@ -12,6 +12,12 @@
   import { Checkbox } from '$lib/components/ui/checkbox'
   import { Label } from '$lib/components/ui/label'
   import { Separator } from '$lib/components/ui/separator'
+  import {
+    buildPlanCreationFields,
+    clearPlanDraft,
+    loadPlanDraft,
+    savePlanDraft,
+  } from '$lib/plan-draft'
   import routes from '$lib/routes'
   import { appStore } from '$lib/stores/app.svelte'
 
@@ -31,6 +37,55 @@
   let selectedLiabilityIds = new SvelteSet((appStore.profile.liabilities ?? []).map((l) => l.id))
   let selectedIncomeIds = new SvelteSet((appStore.profile.incomes ?? []).map((i) => i.id))
   let selectedExpenseIds = new SvelteSet((appStore.profile.expenses ?? []).map((e) => e.id))
+
+  let hydrated = $state(false)
+
+  // Re-seed a SvelteSet in place from an array of ids.
+  function reseed(set: SvelteSet<string>, ids: string[]): void {
+    set.clear()
+    for (const id of ids) set.add(id)
+  }
+
+  // Re-hydrate selections from a previously saved draft exactly once, on first
+  // load, so navigating back to this step preserves the user's choices.
+  $effect(() => {
+    if (hydrated) return
+    const data = loadPlanDraft().data
+    if (data) {
+      includeCash = data.includeCash
+      includeInvestments = data.includeInvestments
+      includeTangibleAssets = data.includeTangibleAssets
+      includeLiabilities = data.includeLiabilities
+      includeIncomes = data.includeIncomes
+      includeExpenses = data.includeExpenses
+      reseed(selectedInvestmentIds, data.selectedInvestmentIds)
+      reseed(selectedTangibleAssetIds, data.selectedTangibleAssetIds)
+      reseed(selectedLiabilityIds, data.selectedLiabilityIds)
+      reseed(selectedIncomeIds, data.selectedIncomeIds)
+      reseed(selectedExpenseIds, data.selectedExpenseIds)
+    }
+    hydrated = true
+  })
+
+  // Persist selections to the draft whenever they change (preserving the
+  // Details step's data), so nothing is lost on back navigation.
+  $effect(() => {
+    if (!hydrated) return
+    const data = {
+      includeCash,
+      includeInvestments,
+      includeTangibleAssets,
+      includeLiabilities,
+      includeIncomes,
+      includeExpenses,
+      selectedInvestmentIds: Array.from(selectedInvestmentIds),
+      selectedTangibleAssetIds: Array.from(selectedTangibleAssetIds),
+      selectedLiabilityIds: Array.from(selectedLiabilityIds),
+      selectedIncomeIds: Array.from(selectedIncomeIds),
+      selectedExpenseIds: Array.from(selectedExpenseIds),
+    }
+    savePlanDraft({ ...loadPlanDraft(), data })
+  })
 
   // Helper to toggle individual item (mutates the set directly since SvelteSet is reactive)
   function toggleItem(set: SvelteSet<string>, id: string): void {
@@ -67,16 +122,26 @@
     includeIncomes = true
     includeExpenses = true
     // Clear and refill SvelteSet (mutate in place)
-    selectedInvestmentIds.clear()
-    for (const i of appStore.profile.investments ?? []) selectedInvestmentIds.add(i.id)
-    selectedTangibleAssetIds.clear()
-    for (const a of appStore.profile.tangible_assets ?? []) selectedTangibleAssetIds.add(a.id)
-    selectedLiabilityIds.clear()
-    for (const l of appStore.profile.liabilities ?? []) selectedLiabilityIds.add(l.id)
-    selectedIncomeIds.clear()
-    for (const i of appStore.profile.incomes ?? []) selectedIncomeIds.add(i.id)
-    selectedExpenseIds.clear()
-    for (const e of appStore.profile.expenses ?? []) selectedExpenseIds.add(e.id)
+    reseed(
+      selectedInvestmentIds,
+      (appStore.profile.investments ?? []).map((i) => i.id),
+    )
+    reseed(
+      selectedTangibleAssetIds,
+      (appStore.profile.tangible_assets ?? []).map((a) => a.id),
+    )
+    reseed(
+      selectedLiabilityIds,
+      (appStore.profile.liabilities ?? []).map((l) => l.id),
+    )
+    reseed(
+      selectedIncomeIds,
+      (appStore.profile.incomes ?? []).map((i) => i.id),
+    )
+    reseed(
+      selectedExpenseIds,
+      (appStore.profile.expenses ?? []).map((e) => e.id),
+    )
   }
 
   function deselectAll() {
@@ -101,32 +166,18 @@
   }
 
   function handleCreatePlan() {
-    // Load plan details from sessionStorage
-    const draftStr = sessionStorage.getItem('kalkul-plan-draft')
-    if (!draftStr) {
+    // Load plan details from the draft
+    const details = loadPlanDraft().details
+    if (!details) {
       // Fallback if no draft
       goto(resolve(routes.HOME))
       return
     }
 
-    const draft = JSON.parse(draftStr) as {
-      name: string
-      notes?: string
-      currency: string
-      start_date: string
-      end_date: string
-      inflation_rate: number
-    }
-
     // Create the portfolio with included references
     // When category is checked: include all items; when unchecked: include only selected items
     const portfolioId = appStore.addPortfolio({
-      name: draft.name,
-      notes: draft.notes,
-      currency: draft.currency,
-      start_date: draft.start_date,
-      end_date: draft.end_date,
-      inflation_rate: draft.inflation_rate,
+      ...buildPlanCreationFields(details, appStore.profile.birthDate),
       include_cash: includeCash,
       included_investment_ids: includeInvestments
         ? (appStore.profile.investments ?? []).map((i) => i.id)
@@ -146,7 +197,7 @@
     })
 
     // Clean up
-    sessionStorage.removeItem('kalkul-plan-draft')
+    clearPlanDraft()
 
     // Navigate to the new plan page
     goto(resolve(`${routes.PLAN_VIEW}/${portfolioId}`))

--- a/src/routes/(add-plan)/plan/add/details/+page.svelte
+++ b/src/routes/(add-plan)/plan/add/details/+page.svelte
@@ -5,7 +5,6 @@
 
   import { goto } from '$app/navigation'
 
-  import { formatDate } from '$lib/@snaha/kalkul-maths'
   import { getNextAddPlanStepUrl, getPrevAddPlanStepUrl } from '$lib/add-plan-steps'
   import SuffixedInput from '$lib/components/suffixed-input.svelte'
   import { Button } from '$lib/components/ui/button'
@@ -13,6 +12,7 @@
   import { Label } from '$lib/components/ui/label'
   import * as Select from '$lib/components/ui/select'
   import { Textarea } from '$lib/components/ui/textarea'
+  import { loadPlanDraft, savePlanDraft } from '$lib/plan-draft'
   import routes from '$lib/routes'
   import type { PlanEndType, PlanStartType } from '$lib/schemas'
   import { appStore } from '$lib/stores/app.svelte'
@@ -35,36 +35,51 @@
   let endMonth = $state('')
   let currency = $state(appStore.profile.currency ?? DEFAULT_CURRENCY)
   let inflation = $state<number | undefined>(2)
+  let hydrated = $state(false)
+
+  // Re-hydrate the form from a previously saved draft exactly once, on first
+  // load, so navigating back to this step preserves the user's entries.
+  $effect(() => {
+    if (hydrated) return
+    const details = loadPlanDraft().details
+    if (details) {
+      name = details.name
+      notes = details.notes
+      startType = details.startType
+      startYear = details.startYear
+      startMonth = details.startMonth
+      endType = details.endType
+      endAge = details.endAge
+      endYear = details.endYear
+      endMonth = details.endMonth
+      currency = details.currency
+      inflation = details.inflation
+    }
+    hydrated = true
+  })
+
+  // Persist the form to the draft whenever it changes (preserving the Data
+  // step's selections), so nothing is lost on back navigation.
+  $effect(() => {
+    if (!hydrated) return
+    const details = {
+      name,
+      notes,
+      startType,
+      startYear,
+      startMonth,
+      endType,
+      endAge,
+      endYear,
+      endMonth,
+      currency,
+      inflation,
+    }
+    savePlanDraft({ ...loadPlanDraft(), details })
+  })
 
   const years = getYearOptions()
   const months = $derived(getMonthOptions($locale ?? undefined))
-
-  // Calculate date from start of current month
-  function getStartDate(): string {
-    if (startType === 'now') {
-      const now = new Date()
-      return formatDate(new Date(now.getFullYear(), now.getMonth(), 1))
-    }
-    return formatDate(new Date(Number(startYear), Number(startMonth), 1))
-  }
-
-  // Calculate end date based on age or specific date
-  function getEndDate(): string {
-    if (endType === 'when_age_is' && endAge !== undefined) {
-      const birthDate = appStore.profile.birthDate
-      if (birthDate) {
-        return formatDate(new Date(birthDate.getFullYear() + endAge, birthDate.getMonth(), 1))
-      }
-      // Fallback: use start year + age
-      const startYearNum = startType === 'now' ? new Date().getFullYear() : Number(startYear)
-      return formatDate(new Date(startYearNum + endAge, 0, 1))
-    }
-    if (endYear && endMonth !== '') {
-      return formatDate(new Date(Number(endYear), Number(endMonth), 1))
-    }
-    // Fallback (unreachable due to canContinue validation)
-    return formatDate(new Date(new Date().getFullYear() + 30, 0, 1))
-  }
 
   let canContinue = $derived(
     name.trim().length > 0 &&
@@ -79,16 +94,6 @@
   }
 
   function handleContinue() {
-    // Store plan details in sessionStorage for step 3
-    const planDetails = {
-      name: name.trim(),
-      notes: notes.trim() || undefined,
-      currency,
-      start_date: getStartDate(),
-      end_date: getEndDate(),
-      inflation_rate: (inflation ?? 2) / 100,
-    }
-    sessionStorage.setItem('kalkul-plan-draft', JSON.stringify(planDetails))
     // URL is already resolved by getNextAddPlanStepUrl
     // eslint-disable-next-line svelte/no-navigation-without-resolve
     goto(getNextAddPlanStepUrl(routes.PLAN_ADD_DETAILS, appStore.profile))


### PR DESCRIPTION
Fixes #76.

## Problem

In the add-plan flow (`/plan/add/...`), navigating **back** wiped everything entered in the Details and Data steps. The draft was written to `sessionStorage` only on Continue, with no re-hydration on mount, so returning to a step re-mounted with hardcoded defaults. The draft also only stored *derived* values (computed `start_date`/`end_date`), which can't faithfully restore raw form choices like "start now" vs "at specific date".

## Fix

New shared module `src/lib/plan-draft.ts` that centralizes:
- the `sessionStorage` key (previously a duplicated string literal in two files),
- a typed draft shape (`{ details?, data? }`) storing the **raw** Details form state plus the Data step's selections,
- `load`/`save`/`clear` helpers and the plan-creation field derivation (`getPlanStartDate`, `getPlanEndDate`, `buildPlanCreationFields`).

Both steps now mirror the existing onboarding `hydrated` `$effect` pattern:
- **Details** — hydrates the form once on mount, persists reactively on change.
- **Data** — hydrates category toggles + per-item selections, persists on change, and builds the portfolio from the draft's raw details at creation time.

Saves merge (`{ ...loadPlanDraft(), details/data }`) so neither step clobbers the other's data, and dates are derived from the raw form at creation so inputs round-trip faithfully.

## Tests

New `src/lib/plan-draft.test.ts` (12 tests): date derivation (now / specific date / by-age with birthDate fallback), field building (trim, empty-notes, inflation→rate), and storage round-trip including the merge-preserves-other-step case and corrupt-draft recovery.

`pnpm check:all` passes (prettier, eslint, svelte-check 0 errors, knip, check-locales).

## Behavior note

An abandoned (uncompleted) draft now survives for the tab session, so restarting "Add plan" restores the in-progress draft rather than fresh defaults — matching the issue's "hydrate from the draft" guidance. Easy to add an entry-point reset if a fresh start is preferred.

## Verification

Live browser verification wasn't possible in the authoring session (preview tooling was pinned to the main working tree, not the worktree). Behavior is covered by the storage round-trip + derivation unit tests and the proven onboarding hydration pattern — worth a manual pass when reviewing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)