### PR TITLE
fix: honor recurring start/end date instead of starting at plan year 1

### DIFF
--- a/src/lib/components/date-age-selector.svelte
+++ b/src/lib/components/date-age-selector.svelte
@@ -14,6 +14,12 @@
     years: string[]
     months: { value: string; label: string }[]
     /**
+     * Whether the profile has a birth date. Age-based timing ('when_age_is')
+     * can't resolve to a year without one, so the option is disabled when this
+     * is false to avoid a transfer/cash-flow silently starting at plan year 1.
+     */
+    birthDateSet?: boolean
+    /**
      * Overrides the option-aware description. When omitted, the description
      * derives from the selected option using shared i18n keys (matches the
      * Figma spec at node 233:6637).
@@ -34,6 +40,7 @@
     age,
     years,
     months,
+    birthDateSet = true,
     description,
     onValueChange,
     onYearChange,
@@ -60,18 +67,25 @@
   let yearString = $derived(year !== undefined ? String(year) : '')
   let monthString = $derived(month !== undefined ? String(month) : '')
 
+  // Age-based timing needs a birth date to resolve to a year; disable it when
+  // none is set so the flow can't silently start at the plan's first year.
+  let whenAgeIsItem = $derived({
+    value: 'when_age_is',
+    label: $_('page.setup.common.whenAgeIs'),
+    disabled: !birthDateSet,
+  })
   let modeItems = $derived(
     mode === 'start'
       ? [
           { value: 'immediately', label: $_('page.setup.common.immediately') },
           { value: 'now', label: $_('page.setup.common.now') },
           { value: 'at_specific_date', label: $_('page.setup.common.atSpecificDate') },
-          { value: 'when_age_is', label: $_('page.setup.common.whenAgeIs') },
+          whenAgeIsItem,
         ]
       : [
           { value: 'never', label: $_('page.setup.common.never') },
           { value: 'at_specific_date', label: $_('page.setup.common.atSpecificDate') },
-          { value: 'when_age_is', label: $_('page.setup.common.whenAgeIs') },
+          whenAgeIsItem,
         ],
   )
   let yearItems = $derived(years.map((y) => ({ value: y, label: y })))

--- a/src/lib/plan-projection.test.ts
+++ b/src/lib/plan-projection.test.ts
@@ -1052,6 +1052,88 @@ describe('getYearlyPlanProjection', () => {
     expect(result[5].investments).toBeCloseTo(7200, 6) // 6 years inclusive
   })
 
+  it('delays a recurring transfer until its at_specific_date start year', () => {
+    const investments: ProfileInvestment[] = [{ id: 'inv1', name: 'Stocks', balance: 0, apy: 0 }]
+    const transfers: Transfer[] = [
+      {
+        id: 't1',
+        name: 'Future DCA',
+        from_asset_id: 'cash',
+        to_asset_id: 'inv1',
+        amount: 100,
+        schedule: 'recurring',
+        frequency: 'monthly',
+        start: 'at_specific_date',
+        start_year: 2028,
+        start_month: 1,
+        end: 'never',
+        change_over_time: 'none',
+      },
+    ]
+    const result = getYearlyPlanProjection(
+      makePlan({ transfers }),
+      makeProfile({ cash_amount: 100_000, investments }),
+    )
+    // Plan runs 2025-2030; transfer starts 2028, so nothing before then.
+    expect(result[0].investments).toBeCloseTo(0, 6) // 2025
+    expect(result[1].investments).toBeCloseTo(0, 6) // 2026
+    expect(result[2].investments).toBeCloseTo(0, 6) // 2027
+    expect(result[3].investments).toBeCloseTo(1200, 6) // 2028
+    expect(result[4].investments).toBeCloseTo(2400, 6) // 2029
+  })
+
+  it('delays a recurring transfer until the when_age_is start year (birth date set)', () => {
+    const investments: ProfileInvestment[] = [{ id: 'inv1', name: 'Stocks', balance: 0, apy: 0 }]
+    const transfers: Transfer[] = [
+      {
+        id: 't1',
+        name: 'Age DCA',
+        from_asset_id: 'cash',
+        to_asset_id: 'inv1',
+        amount: 100,
+        schedule: 'recurring',
+        frequency: 'monthly',
+        start: 'when_age_is',
+        start_age: 48, // born 1980 → starts 2028
+        end: 'never',
+        change_over_time: 'none',
+      },
+    ]
+    const result = getYearlyPlanProjection(
+      makePlan({ transfers }),
+      makeProfile({ cash_amount: 100_000, investments, birth_date: '1980-01-01' }),
+    )
+    expect(result[0].investments).toBeCloseTo(0, 6) // 2025
+    expect(result[2].investments).toBeCloseTo(0, 6) // 2027
+    expect(result[3].investments).toBeCloseTo(1200, 6) // 2028
+  })
+
+  it('falls back to plan start for when_age_is when no birth date is set', () => {
+    // Documents the silent fallback that the dialogs now prevent by disabling
+    // the "when age is" option when the profile has no birth date.
+    const investments: ProfileInvestment[] = [{ id: 'inv1', name: 'Stocks', balance: 0, apy: 0 }]
+    const transfers: Transfer[] = [
+      {
+        id: 't1',
+        name: 'Age DCA',
+        from_asset_id: 'cash',
+        to_asset_id: 'inv1',
+        amount: 100,
+        schedule: 'recurring',
+        frequency: 'monthly',
+        start: 'when_age_is',
+        start_age: 48,
+        end: 'never',
+        change_over_time: 'none',
+      },
+    ]
+    const result = getYearlyPlanProjection(
+      makePlan({ transfers }),
+      makeProfile({ cash_amount: 100_000, investments }), // no birth_date
+    )
+    expect(result[0].investments).toBeCloseTo(1200, 6) // fires from year 1
+  })
+
   it('compounds recurring contributions at apy from the year they arrive', () => {
     // 1000 / year into an account at 10% APY, starting at plan-start.
     // Year 0: deposit 1000 -> balance 1000

--- a/src/routes/(app)/plan/[id]/CashFlowEditDialog.svelte
+++ b/src/routes/(app)/plan/[id]/CashFlowEditDialog.svelte
@@ -24,7 +24,7 @@
   } from '$lib/schemas'
   import { appStore } from '$lib/stores/app.svelte'
   import type { PortfolioStore } from '$lib/stores/portfolio.svelte'
-  import { calculateAge, getMonthOptions, getYearOptions } from '$lib/utils'
+  import { getMonthOptions, getYearOptions } from '$lib/utils'
 
   type CashFlow = Income | Expense
 
@@ -58,13 +58,8 @@
     change_percentage: number | undefined
   }
 
-  const currentYear = new Date().getFullYear()
-  const currentMonth = new Date().getMonth()
   const years = getYearOptions()
   let months = $derived(getMonthOptions($locale ?? undefined))
-  let currentAge = $derived(
-    Number(calculateAge(appStore.profile.birthDate, currentYear, currentMonth)) || undefined,
-  )
   let currencyLabel = $derived(appStore.profile.currencyOrDefault)
 
   let frequencyItems = $derived([
@@ -92,13 +87,15 @@
       // terms, so this matches user intent for the common case.
       inflation_adjusted: true,
       start: 'immediately',
-      start_year: currentYear,
-      start_month: currentMonth,
-      start_age: currentAge,
+      // Timing fields start empty so 'at_specific_date'/'when_age_is' force an
+      // explicit choice instead of silently defaulting to "now" (= plan year 1).
+      start_year: undefined,
+      start_month: undefined,
+      start_age: undefined,
       end: 'never',
-      end_year: currentYear,
-      end_month: currentMonth,
-      end_age: currentAge,
+      end_year: undefined,
+      end_month: undefined,
+      end_age: undefined,
       change_over_time: 'none',
       change_percentage: undefined,
     }
@@ -122,13 +119,13 @@
       tax_percentage: isIncome(src) ? src.tax_percentage : undefined,
       inflation_adjusted: inflationAdjusted,
       start: src.start,
-      start_year: src.start_year ?? currentYear,
-      start_month: src.start_month ?? currentMonth,
-      start_age: src.start_age ?? currentAge,
+      start_year: src.start_year,
+      start_month: src.start_month,
+      start_age: src.start_age,
       end: src.end,
-      end_year: src.end_year ?? currentYear,
-      end_month: src.end_month ?? currentMonth,
-      end_age: src.end_age ?? currentAge,
+      end_year: src.end_year,
+      end_month: src.end_month,
+      end_age: src.end_age,
       change_over_time: changeOverTime,
       change_percentage: src.change_percentage,
     }
@@ -206,6 +203,25 @@
           : undefined,
     }
   }
+
+  // A timing edge ('start' or 'end') is complete only once the mode-specific
+  // field is filled — otherwise the projection would silently fall back to the
+  // plan's first year (see schemas.ts cashFlowTemporalRefinement).
+  function timingComplete(
+    mode: CashFlowStart | CashFlowEnd,
+    year: number | undefined,
+    month: number | undefined,
+    age: number | undefined,
+  ): boolean {
+    if (mode === 'at_specific_date') return year !== undefined && month !== undefined
+    if (mode === 'when_age_is') return age !== undefined
+    return true
+  }
+
+  const canSave = $derived(
+    timingComplete(form.start, form.start_year, form.start_month, form.start_age) &&
+      timingComplete(form.end, form.end_year, form.end_month, form.end_age),
+  )
 
   function close() {
     onOpenChange(false)
@@ -445,6 +461,7 @@
         age={form.start_age}
         {years}
         {months}
+        birthDateSet={appStore.profile.birthDate !== undefined}
         formatNumber={appStore.formatNumber}
         onValueChange={(v) => (form.start = v as CashFlowStart)}
         onYearChange={(v) => (form.start_year = v)}
@@ -460,6 +477,7 @@
         age={form.end_age}
         {years}
         {months}
+        birthDateSet={appStore.profile.birthDate !== undefined}
         formatNumber={appStore.formatNumber}
         onValueChange={(v) => (form.end = v as CashFlowEnd)}
         onYearChange={(v) => (form.end_year = v)}
@@ -478,7 +496,7 @@
 
     <Dialog.Footer class="flex flex-row justify-end gap-2 border-t p-4">
       <Button variant="secondary" onclick={close}>{$_('page.plan.cancel')}</Button>
-      <Button onclick={save}>{$_('page.plan.saveChanges')}</Button>
+      <Button onclick={save} disabled={!canSave}>{$_('page.plan.saveChanges')}</Button>
     </Dialog.Footer>
   </Dialog.Content>
 </Dialog.Root>

--- a/src/routes/(app)/plan/[id]/TransferEditDialog.svelte
+++ b/src/routes/(app)/plan/[id]/TransferEditDialog.svelte
@@ -24,7 +24,7 @@
   } from '$lib/schemas'
   import { appStore } from '$lib/stores/app.svelte'
   import type { PortfolioStore } from '$lib/stores/portfolio.svelte'
-  import { calculateAge, getMonthOptions, getYearOptions } from '$lib/utils'
+  import { getMonthOptions, getYearOptions } from '$lib/utils'
 
   interface Props {
     open: boolean
@@ -65,9 +65,6 @@
   const currentMonth = new Date().getMonth()
   const years = getYearOptions()
   let months = $derived(getMonthOptions($locale ?? undefined))
-  let currentAge = $derived(
-    Number(calculateAge(appStore.profile.birthDate, currentYear, currentMonth)) || undefined,
-  )
   let currencyLabel = $derived(appStore.profile.currencyOrDefault)
 
   // Build the From/To asset list from the profile, filtered by plan inclusion
@@ -113,13 +110,15 @@
       transaction_month: currentMonth + 1,
       frequency: 'monthly',
       start: 'immediately',
-      start_year: currentYear,
-      start_month: currentMonth + 1,
-      start_age: currentAge,
+      // Timing fields start empty so 'at_specific_date'/'when_age_is' force an
+      // explicit choice instead of silently defaulting to "now" (= plan year 1).
+      start_year: undefined,
+      start_month: undefined,
+      start_age: undefined,
       end: 'never',
-      end_year: currentYear,
-      end_month: currentMonth + 1,
-      end_age: currentAge,
+      end_year: undefined,
+      end_month: undefined,
+      end_age: undefined,
       change_over_time: 'none',
       change_percentage: undefined,
     }
@@ -139,13 +138,13 @@
     f.transaction_month = src.transaction_month ?? currentMonth + 1
     f.frequency = src.frequency ?? 'monthly'
     f.start = src.start ?? 'immediately'
-    f.start_year = src.start_year ?? currentYear
-    f.start_month = src.start_month ?? currentMonth + 1
-    f.start_age = src.start_age ?? currentAge
+    f.start_year = src.start_year
+    f.start_month = src.start_month
+    f.start_age = src.start_age
     f.end = src.end ?? 'never'
-    f.end_year = src.end_year ?? currentYear
-    f.end_month = src.end_month ?? currentMonth + 1
-    f.end_age = src.end_age ?? currentAge
+    f.end_year = src.end_year
+    f.end_month = src.end_month
+    f.end_age = src.end_age
     // Legacy migration: old change_over_time='match_inflation' folds into the
     // new toggle and the dropdown collapses to 'none'.
     const legacyInflation = src.change_over_time === 'match_inflation'
@@ -302,11 +301,28 @@
     close()
   }
 
+  // A timing edge ('start' or 'end') is complete only once the mode-specific
+  // field is filled — otherwise the projection would silently fall back to the
+  // plan's first year (see schemas.ts cashFlowTemporalRefinement).
+  function timingComplete(
+    mode: CashFlowStart | CashFlowEnd,
+    year: number | undefined,
+    month: number | undefined,
+    age: number | undefined,
+  ): boolean {
+    if (mode === 'at_specific_date') return year !== undefined && month !== undefined
+    if (mode === 'when_age_is') return age !== undefined
+    return true
+  }
+
   const canSave = $derived(
     form.from_asset_id !== '' &&
       form.to_asset_id !== '' &&
       form.from_asset_id !== form.to_asset_id &&
-      (form.transfer_all || (form.amount ?? 0) > 0),
+      (form.transfer_all || (form.amount ?? 0) > 0) &&
+      (form.schedule === 'one_time' ||
+        (timingComplete(form.start, form.start_year, form.start_month, form.start_age) &&
+          timingComplete(form.end, form.end_year, form.end_month, form.end_age))),
   )
 </script>
 
@@ -495,6 +511,7 @@
           age={form.start_age}
           {years}
           {months}
+          birthDateSet={appStore.profile.birthDate !== undefined}
           formatNumber={appStore.formatNumber}
           onValueChange={(v) => (form.start = v as CashFlowStart)}
           onYearChange={(v) => (form.start_year = v)}
@@ -510,6 +527,7 @@
           age={form.end_age}
           {years}
           {months}
+          birthDateSet={appStore.profile.birthDate !== undefined}
           formatNumber={appStore.formatNumber}
           onValueChange={(v) => (form.end = v as CashFlowEnd)}
           onYearChange={(v) => (form.end_year = v)}


### PR DESCRIPTION
## Problem

On the plan page, a recurring transfer (or income/expense) with a start of **"When age is"** or **"At specific date"** started from the plan's **first year** instead of the chosen point in time.

The projection was correct — the dialogs were feeding it "now"-equivalent data:

- `blankForm()` pre-filled `start_age`/`end_age` to the user's **current age** and `start_year`/`end_year` to the **current year**. The controls don't emit on mount, so selecting a mode without changing the pre-filled value saved a value meaning *now* → resolved to plan year 1.
- "When age is" also silently fell back to year 1 when the profile had **no birth date** (age can't resolve to a year).

## Fix

- `blankForm()`/`seedForm()` leave timing fields `undefined`, forcing an explicit choice
- Block **Save** until the mode's field is filled — `at_specific_date` → year+month, `when_age_is` → age (the cash-flow dialog had no save guard before)
- Disable "When age is" when no birth date is set (shared `date-age-selector`)
- Add regression tests for `at_specific_date` and `when_age_is` (with and without a birth date)

🤖 Generated with [Claude Code](https://claude.com/claude-code)