### PR TITLE
fix: remove focus border on chart columns

### DIFF
--- a/src/lib/components/stacked-bar-chart.svelte
+++ b/src/lib/components/stacked-bar-chart.svelte
@@ -324,7 +324,7 @@
   <!-- Bars -->
   {#each bars as bar (bar.year)}
     <g
-      class="cursor-pointer transition-opacity"
+      class="cursor-pointer transition-opacity focus:outline-none"
       class:opacity-60={hoveredYear !== undefined && bar.year === hoveredYear}
       role="button"
       tabindex="0"
@@ -332,6 +332,8 @@
       onkeydown={(e) => handleKeyDown(e, bar.year)}
       onmouseenter={() => handleBarMouseEnter(bar)}
       onmouseleave={handleBarMouseLeave}
+      onfocus={() => handleBarMouseEnter(bar)}
+      onblur={handleBarMouseLeave}
       aria-label="Year {bar.year}"
     >
       <!-- Invisible hit area to prevent tooltip flashing between bars -->


### PR DESCRIPTION
Clicking a column drew the browser's default focus outline (visible in Brave). Suppressed with `focus:outline-none`.

Because `:focus-visible` is unreliable on SVG `<g>`, keyboard focus now reuses the existing hover indicator (dashed line + tooltip) so columns still have a visible focus state.

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)