### PR TITLE
docs: add commit and PR conventions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,7 +149,7 @@ When linking from a bare `<a>` tag (not the `Button` component), the `svelte/no-
 
 - Use [conventional commits](https://www.conventionalcommits.org/) (e.g. `fix:`, `feat:`, `chore:`).
 - Keep PR titles and descriptions concise.
-- Omit the issue number from branch names
+- Omit the issue number from branch names and titles
 - When a PR resolves an issue, reference it with a closing keyword (e.g. `Closes #53`) so GitHub closes the issue automatically on merge.
 
 ### Common Tasks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,12 @@ When linking from a bare `<a>` tag (not the `Button` component), the `svelte/no-
    - ❌ Placing component-used images in `static/` and referencing via `{base}/path`
    - The `static/` folder is reserved for files that need fixed URLs: favicons, PWA icons, `manifest.json`, fonts
 
+### Commits & Pull Requests
+
+- Use [conventional commits](https://www.conventionalcommits.org/) (e.g. `fix:`, `feat:`, `chore:`).
+- Keep PR titles and descriptions concise.
+- When a PR resolves an issue, reference it with a closing keyword (e.g. `Closes #53`) so GitHub closes the issue automatically on merge.
+
 ### Common Tasks
 
 1. **Adding a New Feature**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,7 @@ When linking from a bare `<a>` tag (not the `Button` component), the `svelte/no-
 
 - Use [conventional commits](https://www.conventionalcommits.org/) (e.g. `fix:`, `feat:`, `chore:`).
 - Keep PR titles and descriptions concise.
+- Omit the issue number from branch names
 - When a PR resolves an issue, reference it with a closing keyword (e.g. `Closes #53`) so GitHub closes the issue automatically on merge.
 
 ### Common Tasks


### PR DESCRIPTION
Documents existing practice in AGENTS.md: use conventional commits, keep PR titles/descriptions concise, and reference issues with a closing keyword (e.g. `Closes #53`) so GitHub auto-closes them on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)