### PR TITLE
fix: remove pie chart from cash page

### DIFF
--- a/src/routes/(app)/financial-data/cash/+page.svelte
+++ b/src/routes/(app)/financial-data/cash/+page.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
   import { _, locale } from 'svelte-i18n'
 
-  import { CATEGORY_COLORS } from '$lib/chart-colors'
-  import DonutChart from '$lib/components/donut-chart.svelte'
   import SuffixedInput from '$lib/components/suffixed-input.svelte'
   import { Label } from '$lib/components/ui/label'
   import { getCashTotal } from '$lib/financial-totals'
@@ -11,10 +9,6 @@
 
   const cash = $derived(getCashTotal(appStore.profile))
 
-  const segments = $derived(
-    cash > 0 ? [{ label: 'cash', value: cash, color: CATEGORY_COLORS.cash }] : [],
-  )
-
   const lastUpdatedDate = $derived(formatLastUpdated(appStore.lastUpdated, $locale))
 
   function handleCashChange(value: number | undefined) {
@@ -22,15 +16,12 @@
   }
 </script>
 
-<div class="flex w-full flex-col items-start gap-4 sm:flex-row sm:items-center sm:gap-8">
-  <DonutChart {segments} size={160} variant="pie" />
-  <div class="flex flex-1 flex-col items-start gap-2">
-    <p class="text-lg leading-7 font-medium">{$_('page.financialData.cash.title')}</p>
-    <p class="text-3xl leading-9 font-bold">{appStore.formatCurrencyCode(cash)}</p>
-    <span class="text-xs leading-4 text-muted-foreground">
-      {$_('page.financialData.overview.lastUpdated', { values: { date: lastUpdatedDate } })}
-    </span>
-  </div>
+<div class="flex w-full flex-col items-start gap-2">
+  <p class="text-lg leading-7 font-medium">{$_('page.financialData.cash.title')}</p>
+  <p class="text-3xl leading-9 font-bold">{appStore.formatCurrencyCode(cash)}</p>
+  <span class="text-xs leading-4 text-muted-foreground">
+    {$_('page.financialData.overview.lastUpdated', { values: { date: lastUpdatedDate } })}
+  </span>
 </div>
 
 <div class="flex w-full flex-col items-start gap-2">


### PR DESCRIPTION
Cash is a single value (no multiple accounts), so the pie chart always rendered one 100% segment. Per the [Figma spec](https://www.figma.com/design/u1YcZl99L5kTD128oxU1Nt/Kalkul_v4?node-id=480-53431), the chart is removed while the title, amount, and last-updated line stay (now left-aligned). The shared `DonutChart` component is untouched — still used by other pages.

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)