### PR TITLE
fix: header button hover (#35) + financial overview separators (#42)

### DIFF
--- a/src/lib/components/navbar.svelte
+++ b/src/lib/components/navbar.svelte
@@ -76,11 +76,16 @@
     <img src={logo} alt="Kalkul" class="size-9" />
   </a>
   <div class="flex items-center gap-4">
-    <ThemeSwitcher class="text-white hover:bg-white/10" />
+    <ThemeSwitcher class="text-white hover:bg-white/10 hover:text-white dark:hover:bg-white/10" />
     <DropdownMenu.Root>
       <DropdownMenu.Trigger>
         {#snippet child({ props })}
-          <Button variant="ghost" size="icon" class="text-white hover:bg-white/10" {...props}>
+          <Button
+            variant="ghost"
+            size="icon"
+            class="text-white hover:bg-white/10 hover:text-white dark:hover:bg-white/10"
+            {...props}
+          >
             <EllipsisVertical class="size-4" />
           </Button>
         {/snippet}

--- a/src/routes/(app)/financial-data/+page.svelte
+++ b/src/routes/(app)/financial-data/+page.svelte
@@ -9,6 +9,7 @@
   import BreakdownRow from '$lib/components/breakdown-row.svelte'
   import DonutChart from '$lib/components/donut-chart.svelte'
   import { Button } from '$lib/components/ui/button'
+  import { Separator } from '$lib/components/ui/separator'
   import {
     getCashTotal,
     getInvestmentsTotal,
@@ -68,17 +69,20 @@
     amount={appStore.formatCurrencyCode(tangible)}
     color={CATEGORY_COLORS.tangibleAssets[0]}
   />
+  <Separator />
   <BreakdownRow
     label={$_('page.financialData.overview.totalAssets')}
     amount={appStore.formatCurrencyCode(totalAssets)}
     bold
   />
+  <Separator />
   <BreakdownRow
     label={$_('page.financialData.nav.liabilities')}
     amount={appStore.formatCurrencyCode(-liabilities)}
     color={CATEGORY_COLORS.liabilities[0]}
     negative
   />
+  <Separator />
   <BreakdownRow
     label={$_('page.financialData.overview.netWorth')}
     amount={appStore.formatCurrencyCode(netWorth)}


### PR DESCRIPTION
Two small UI fixes bundled for review.

## #35 — Header button hover state colors are wrong
On hover the header icon buttons (theme switcher + kebab menu) turned dark and became invisible against the dark (`bg-neutral-950`) header.

**Cause:** the `ghost` button variant applies `dark:hover:bg-muted/50`. The inline `hover:bg-white/10` is a *different* modifier (`hover:` vs `dark:hover:`), so tailwind-merge keeps both, and in dark mode the `.dark`-scoped rule wins on specificity → dark hover background.

**Fix:** add a matching `dark:hover:bg-white/10` (so the merge drops `dark:hover:bg-muted/50`) and pin `hover:text-white` so the icon stays visible in both themes. Applied to both header icon buttons in `navbar.svelte`.

Fixes #35

## #42 — Missing separating lines on Financial data / overview page
Per Figma, the breakdown list needs separator lines above **Total assets**, above **Liabilities**, and above **Net worth**.

**Fix:** insert the existing shadcn `<Separator />` at those three spots in `financial-data/+page.svelte`.

Fixes #42 

🤖 Generated with [Claude Code](https://claude.com/claude-code)