### PR TITLE
fix: use profile currency on add-plan details after store load

### DIFF
--- a/src/routes/(add-plan)/plan/add/details/+page.svelte
+++ b/src/routes/(add-plan)/plan/add/details/+page.svelte
@@ -33,11 +33,18 @@
   let endAge = $state<number | undefined>(85)
   let endYear = $state('')
   let endMonth = $state('')
-  // Writable $derived: tracks the profile currency once the store finishes loading
-  // (avoids a stale EUR default on reload/deep-link), while bind:value still lets the
-  // user override it — nothing here mutates profile.currency, so the override sticks.
-  let currency = $derived(appStore.profile.currency ?? DEFAULT_CURRENCY)
+  let currency = $state(DEFAULT_CURRENCY)
   let inflation = $state<number | undefined>(2)
+  let hydrated = $state(false)
+
+  // The store loads localStorage asynchronously, so profile.currency is undefined
+  // at component init. Copy it once load completes (avoids a stale EUR default on
+  // reload/deep-link); after that the user's bind:value selection is left alone.
+  $effect(() => {
+    if (hydrated || appStore.loading) return
+    if (appStore.profile.currency) currency = appStore.profile.currency
+    hydrated = true
+  })
 
   const years = getYearOptions()
   const months = $derived(getMonthOptions($locale ?? undefined))

--- a/src/routes/(add-plan)/plan/add/details/+page.svelte
+++ b/src/routes/(add-plan)/plan/add/details/+page.svelte
@@ -33,7 +33,10 @@
   let endAge = $state<number | undefined>(85)
   let endYear = $state('')
   let endMonth = $state('')
-  let currency = $state(appStore.profile.currency ?? DEFAULT_CURRENCY)
+  // Writable $derived: tracks the profile currency once the store finishes loading
+  // (avoids a stale EUR default on reload/deep-link), while bind:value still lets the
+  // user override it — nothing here mutates profile.currency, so the override sticks.
+  let currency = $derived(appStore.profile.currency ?? DEFAULT_CURRENCY)
   let inflation = $state<number | undefined>(2)
 
   const years = getYearOptions()


### PR DESCRIPTION
On the add-plan Details step, the currency select could default to **EUR** even when the user's profile currency was something else (e.g. CZK). On a full page load / reload / deep-link of this wizard step, `appStore.profile.currency` is still `undefined` at component init (the store loads localStorage asynchronously), so the one-time `$state` initializer fell back to `DEFAULT_CURRENCY` and never updated once the store finished loading.

Fix: make `currency` a writable `$derived` so it tracks the profile currency once the store loads, while `bind:value` still lets the user override it.

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)