### PR TITLE
fix: persist add-plan & onboarding forms across step navigation (#76)

### DIFF
--- a/src/lib/components/leave-confirm-dialog.svelte
+++ b/src/lib/components/leave-confirm-dialog.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import { _ } from 'svelte-i18n'
+
+  import { Button } from '$lib/components/ui/button'
+  import * as Dialog from '$lib/components/ui/dialog'
+  import { leaveGuard } from '$lib/stores/leave-guard.svelte'
+
+  function onOpenChange(open: boolean): void {
+    // Closing via overlay/escape counts as staying.
+    if (!open) leaveGuard.dismiss()
+  }
+</script>
+
+<Dialog.Root open={leaveGuard.open} {onOpenChange}>
+  <Dialog.Content class="sm:max-w-md">
+    <Dialog.Header>
+      <Dialog.Title>{$_('common.leaveConfirm.title')}</Dialog.Title>
+      <Dialog.Description>{$_('common.leaveConfirm.description')}</Dialog.Description>
+    </Dialog.Header>
+    <Dialog.Footer>
+      <Button variant="ghost" onclick={() => leaveGuard.dismiss()}>
+        {$_('common.leaveConfirm.stay')}
+      </Button>
+      <Button variant="destructive" onclick={() => leaveGuard.confirm()}>
+        {$_('common.leaveConfirm.leave')}
+      </Button>
+    </Dialog.Footer>
+  </Dialog.Content>
+</Dialog.Root>

--- a/src/lib/locales/cs.json
+++ b/src/lib/locales/cs.json
@@ -356,7 +356,13 @@
       "france": "Francie",
       "other": "Jiné"
     },
-    "currency": "Měna"
+    "currency": "Měna",
+    "leaveConfirm": {
+      "title": "Zahodit neuložené změny?",
+      "description": "Pokud nyní odejdete, neuložené změny budou ztraceny.",
+      "stay": "Zůstat",
+      "leave": "Odejít"
+    }
   },
   "theme": {
     "light": "Světlý",

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -356,7 +356,13 @@
       "france": "France",
       "other": "Other"
     },
-    "currency": "Currency"
+    "currency": "Currency",
+    "leaveConfirm": {
+      "title": "Discard unsaved changes?",
+      "description": "If you leave now, the changes you haven't saved will be lost.",
+      "stay": "Stay",
+      "leave": "Leave"
+    }
   },
   "theme": {
     "light": "Light",

--- a/src/lib/plan-draft.test.ts
+++ b/src/lib/plan-draft.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  type PlanDraftDetails,
+  buildPlanCreationFields,
+  getPlanEndDate,
+  getPlanStartDate,
+} from './plan-draft'
+
+function makeDetails(overrides: Partial<PlanDraftDetails> = {}): PlanDraftDetails {
+  return {
+    name: 'My plan',
+    notes: 'some notes',
+    startType: 'at_specific_date',
+    startYear: '2030',
+    startMonth: '5', // June (0-indexed)
+    endType: 'at_specific_date',
+    endAge: undefined,
+    endYear: '2050',
+    endMonth: '0', // January
+    currency: 'CZK',
+    inflation: 2,
+    ...overrides,
+  }
+}
+
+describe('getPlanStartDate', () => {
+  it('uses the first of the selected year/month for a specific start date', () => {
+    expect(getPlanStartDate(makeDetails())).toBe('2030-06-01')
+  })
+
+  it('uses the first of the current month when starting now', () => {
+    const now = new Date()
+    const expected = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-01`
+    expect(getPlanStartDate(makeDetails({ startType: 'now' }))).toBe(expected)
+  })
+})
+
+describe('getPlanEndDate', () => {
+  it('derives the end date from birth date + age when ending by age', () => {
+    const details = makeDetails({ endType: 'when_age_is', endAge: 85 })
+    const birthDate = new Date(1990, 2, 15) // March 1990
+    // 1990 + 85 = 2075, month preserved (March, 0-indexed 2), first of month
+    expect(getPlanEndDate(details, birthDate)).toBe('2075-03-01')
+  })
+
+  it('falls back to start year + age when birth date is unknown', () => {
+    const details = makeDetails({
+      startType: 'at_specific_date',
+      startYear: '2030',
+      endType: 'when_age_is',
+      endAge: 85,
+    })
+    expect(getPlanEndDate(details, undefined)).toBe('2115-01-01')
+  })
+
+  it('uses the selected year/month for a specific end date', () => {
+    expect(getPlanEndDate(makeDetails(), undefined)).toBe('2050-01-01')
+  })
+})
+
+describe('buildPlanCreationFields', () => {
+  it('trims the name, drops empty notes, and converts inflation to a rate', () => {
+    const details = makeDetails({ name: '  Spaced  ', notes: '   ', inflation: 3 })
+    const fields = buildPlanCreationFields(details, undefined)
+    expect(fields.name).toBe('Spaced')
+    expect(fields.notes).toBeUndefined()
+    expect(fields.inflation_rate).toBe(0.03)
+    expect(fields.currency).toBe('CZK')
+    expect(fields.start_date).toBe('2030-06-01')
+    expect(fields.end_date).toBe('2050-01-01')
+  })
+
+  it('defaults inflation to 2% when undefined', () => {
+    const fields = buildPlanCreationFields(makeDetails({ inflation: undefined }), undefined)
+    expect(fields.inflation_rate).toBe(0.02)
+  })
+})

--- a/src/lib/plan-draft.ts
+++ b/src/lib/plan-draft.ts
@@ -1,0 +1,69 @@
+import { formatDate } from '$lib/@snaha/kalkul-maths'
+import type { PlanEndType, PlanStartType } from '$lib/schemas'
+
+/** Raw form state of the add-plan "Details" step. */
+export interface PlanDraftDetails {
+  name: string
+  notes: string
+  startType: PlanStartType
+  startYear: string
+  startMonth: string
+  endType: PlanEndType
+  endAge: number | undefined
+  endYear: string
+  endMonth: string
+  currency: string
+  inflation: number | undefined
+}
+
+/** Values derived from the Details step that are needed to create the portfolio. */
+export interface PlanCreationFields {
+  name: string
+  notes: string | undefined
+  currency: string
+  start_date: string
+  end_date: string
+  inflation_rate: number
+}
+
+/** Compute the plan start date from the raw "Details" form state. */
+export function getPlanStartDate(details: PlanDraftDetails): string {
+  if (details.startType === 'now') {
+    const now = new Date()
+    return formatDate(new Date(now.getFullYear(), now.getMonth(), 1))
+  }
+  return formatDate(new Date(Number(details.startYear), Number(details.startMonth), 1))
+}
+
+/** Compute the plan end date from the raw "Details" form state and the user's birth date. */
+export function getPlanEndDate(details: PlanDraftDetails, birthDate: Date | undefined): string {
+  if (details.endType === 'when_age_is' && details.endAge !== undefined) {
+    if (birthDate) {
+      return formatDate(new Date(birthDate.getFullYear() + details.endAge, birthDate.getMonth(), 1))
+    }
+    // Fallback: use start year + age
+    const startYearNum =
+      details.startType === 'now' ? new Date().getFullYear() : Number(details.startYear)
+    return formatDate(new Date(startYearNum + details.endAge, 0, 1))
+  }
+  if (details.endYear && details.endMonth !== '') {
+    return formatDate(new Date(Number(details.endYear), Number(details.endMonth), 1))
+  }
+  // Fallback (unreachable due to canContinue validation)
+  return formatDate(new Date(new Date().getFullYear() + 30, 0, 1))
+}
+
+/** Build the portfolio-creation fields from the "Details" form state. */
+export function buildPlanCreationFields(
+  details: PlanDraftDetails,
+  birthDate: Date | undefined,
+): PlanCreationFields {
+  return {
+    name: details.name.trim(),
+    notes: details.notes.trim() || undefined,
+    currency: details.currency,
+    start_date: getPlanStartDate(details),
+    end_date: getPlanEndDate(details, birthDate),
+    inflation_rate: (details.inflation ?? 2) / 100,
+  }
+}

--- a/src/lib/stores/leave-guard.svelte.ts
+++ b/src/lib/stores/leave-guard.svelte.ts
@@ -1,0 +1,63 @@
+import { beforeNavigate, goto } from '$app/navigation'
+
+/**
+ * Shared guard that warns before abandoning a multi-step flow (onboarding,
+ * add-plan) with unsaved changes.
+ *
+ * Navigation between steps and the flow's own programmatic navigation use
+ * `goto()` (navigation type `'goto'`), which is never intercepted — those are
+ * handled by per-step snapshots and explicit saves. Only `'link'` clicks (the
+ * header X) and `'popstate'` (browser back/forward) that leave the flow are
+ * intercepted, and only while the active flow reports unsaved changes.
+ */
+class LeaveGuard {
+  /** The destination awaiting confirmation; `undefined` means the dialog is closed. */
+  pendingUrl = $state<URL | undefined>(undefined)
+
+  /** Live check for whether the active flow has unsaved changes. */
+  #isDirty: () => boolean = () => false
+
+  get open(): boolean {
+    return this.pendingUrl !== undefined
+  }
+
+  /** Register the dirty-check for the currently mounted flow. */
+  setDirtyCheck(check: () => boolean): void {
+    this.#isDirty = check
+  }
+
+  /**
+   * Install the navigation guard for a flow whose routes share `flowGroupId`
+   * (e.g. `'(onboarding)'`). Call once during the flow layout's initialisation.
+   */
+  guard(flowGroupId: string): void {
+    beforeNavigate((navigation) => {
+      // Only intercept user-driven exits: the header X (link) and browser
+      // back/forward (popstate). The flow's own goto()-based navigation passes.
+      if (navigation.type !== 'link' && navigation.type !== 'popstate') return
+      if (!this.#isDirty()) return
+      const toId = navigation.to?.route.id
+      // Staying inside the flow (another step) is safe — snapshots preserve it.
+      if (!navigation.to || toId?.includes(flowGroupId)) return
+      navigation.cancel()
+      this.pendingUrl = navigation.to.url
+    })
+  }
+
+  /** Proceed to the pending destination, discarding unsaved changes. */
+  confirm(): void {
+    const url = this.pendingUrl
+    this.pendingUrl = undefined
+    // `url` is the already-resolved destination captured from `navigation.to.url`.
+    // goto() is navigation type 'goto', so it is not re-intercepted by the guard.
+    // eslint-disable-next-line svelte/no-navigation-without-resolve
+    if (url) goto(url)
+  }
+
+  /** Keep the user on the current page. */
+  dismiss(): void {
+    this.pendingUrl = undefined
+  }
+}
+
+export const leaveGuard = new LeaveGuard()

--- a/src/lib/stores/onboarding-draft.svelte.ts
+++ b/src/lib/stores/onboarding-draft.svelte.ts
@@ -1,0 +1,355 @@
+import type {
+  Expense,
+  Frequency,
+  Income,
+  ProfileInvestment,
+  ProfileLiability,
+  ProfileTangibleAsset,
+  TangibleAssetStatus,
+} from '$lib/schemas'
+import { stableStringify } from '$lib/utils'
+
+import { appStore } from './app.svelte'
+
+/** UI-shaped rows: the persisted data plus transient editing flags. */
+export type IncomeUI = Omit<Income, 'amount'> & {
+  amount: number | undefined
+  showAdvanced: boolean
+  editing: boolean
+  editingName: boolean
+}
+
+export type ExpenseUI = Omit<Expense, 'amount'> & {
+  amount: number | undefined
+  showAdvanced: boolean
+  editing: boolean
+  editingName: boolean
+}
+
+export interface InvestmentUI {
+  id: string
+  name: string
+  balance: number | undefined
+  apy: number | undefined
+  editing: boolean
+  editingName: boolean
+}
+
+export interface LiabilityUI {
+  id: string
+  name: string
+  outstanding_balance: number | undefined
+  installment_frequency: Frequency
+  annual_rate: number | undefined
+  installment_amount: number | undefined
+  remaining_term: number | undefined
+  editing: boolean
+  editingName: boolean
+}
+
+export interface AssetUI {
+  id: string
+  name: string
+  value: number | undefined
+  status: TangibleAssetStatus
+  outstanding_balance: number | undefined
+  installment_frequency: Frequency
+  annual_rate: number | undefined
+  installment_amount: number | undefined
+  remaining_term: number | undefined
+  editing: boolean
+  editingName: boolean
+}
+
+/**
+ * Shared reactive draft for the multi-step onboarding flow.
+ *
+ * The `(onboarding)` layout stays mounted across all steps, so holding the
+ * in-progress form state here preserves it across the wizard's `goto()`-based
+ * Back/Continue navigation (SvelteKit snapshots only restore on browser
+ * back/forward, not `goto()`). The layout seeds a fresh draft from the profile
+ * on entry; each step commits its slice to `appStore` on Continue. Mirrors the
+ * add-plan `planDraftStore` pattern.
+ */
+class OnboardingDraftStore {
+  // --- Profile step ---
+  name = $state('')
+  birthYear = $state('')
+  birthMonth = $state('')
+  location = $state('')
+  currency = $state('')
+  userChangedCurrency = $state(false)
+
+  // --- Finances overview step ---
+  cashAmount = $state<number | undefined>(undefined)
+  hasInvestments = $state(false)
+  hasTangibleAssets = $state(false)
+  hasLiabilities = $state(false)
+
+  // --- Category steps ---
+  incomes = $state<IncomeUI[]>([])
+  incomeCounter = $state(0)
+  expenses = $state<ExpenseUI[]>([])
+  expenseCounter = $state(0)
+  investments = $state<InvestmentUI[]>([])
+  investmentCounter = $state(0)
+  liabilities = $state<LiabilityUI[]>([])
+  liabilityCounter = $state(0)
+  assets = $state<AssetUI[]>([])
+  assetCounter = $state(0)
+
+  /** Re-seed the whole draft from the current profile, for a fresh flow entry. */
+  reset(): void {
+    const p = appStore.profile
+    this.name = p.name
+    const birthDate = p.birthDate
+    this.birthYear = birthDate ? String(birthDate.getFullYear()) : ''
+    this.birthMonth = birthDate ? String(birthDate.getMonth()) : ''
+    this.location = p.location ?? ''
+    this.currency = p.currency ?? ''
+    this.userChangedCurrency = false
+
+    this.cashAmount = p.cash_amount
+    this.hasInvestments = p.has_investments ?? false
+    this.hasTangibleAssets = p.has_tangible_assets ?? false
+    this.hasLiabilities = p.has_liabilities ?? false
+
+    this.incomes = incomesToUI(p.incomes ?? [])
+    this.incomeCounter = this.incomes.length
+    this.expenses = expensesToUI(p.expenses ?? [])
+    this.expenseCounter = this.expenses.length
+    this.investments = investmentsToUI(p.investments ?? [])
+    this.investmentCounter = this.investments.length
+    this.liabilities = liabilitiesToUI(p.liabilities ?? [])
+    this.liabilityCounter = this.liabilities.length
+    this.assets = assetsToUI(p.tangible_assets ?? [])
+    this.assetCounter = this.assets.length
+  }
+
+  // --- Build committable data from the current UI rows ---
+  buildIncomes(): Income[] {
+    return this.incomes
+      .filter((i) => i.name.trim().length > 0)
+      .map((i) => ({
+        id: i.id,
+        name: i.name,
+        amount: i.amount ?? 0,
+        frequency: i.frequency,
+        withhold_taxes: i.withhold_taxes,
+        tax_percentage: i.tax_percentage,
+        start: i.start,
+        start_year: i.start === 'at_specific_date' ? i.start_year : undefined,
+        start_month: i.start === 'at_specific_date' ? i.start_month : undefined,
+        start_age: i.start === 'when_age_is' ? i.start_age : undefined,
+        end: i.end,
+        end_year: i.end === 'at_specific_date' ? i.end_year : undefined,
+        end_month: i.end === 'at_specific_date' ? i.end_month : undefined,
+        end_age: i.end === 'when_age_is' ? i.end_age : undefined,
+        change_over_time: i.change_over_time,
+        change_percentage:
+          i.change_over_time === 'increase_yearly' || i.change_over_time === 'decrease_yearly'
+            ? (i.change_percentage ?? 0)
+            : undefined,
+      }))
+  }
+
+  buildExpenses(): Expense[] {
+    return this.expenses
+      .filter((e) => e.name.trim().length > 0)
+      .map((e) => ({
+        id: e.id,
+        name: e.name,
+        amount: e.amount ?? 0,
+        frequency: e.frequency,
+        start: e.start,
+        start_year: e.start === 'at_specific_date' ? e.start_year : undefined,
+        start_month: e.start === 'at_specific_date' ? e.start_month : undefined,
+        start_age: e.start === 'when_age_is' ? e.start_age : undefined,
+        end: e.end,
+        end_year: e.end === 'at_specific_date' ? e.end_year : undefined,
+        end_month: e.end === 'at_specific_date' ? e.end_month : undefined,
+        end_age: e.end === 'when_age_is' ? e.end_age : undefined,
+        change_over_time: e.change_over_time,
+        change_percentage:
+          e.change_over_time === 'increase_yearly' || e.change_over_time === 'decrease_yearly'
+            ? (e.change_percentage ?? 0)
+            : undefined,
+      }))
+  }
+
+  buildInvestments(): ProfileInvestment[] {
+    return this.investments
+      .filter((i) => i.name.trim().length > 0)
+      .map((i) => ({ id: i.id, name: i.name, balance: i.balance ?? 0, apy: i.apy ?? 0 }))
+  }
+
+  buildLiabilities(): ProfileLiability[] {
+    return this.liabilities
+      .filter((l) => l.name.trim().length > 0)
+      .map((l) => ({
+        id: l.id,
+        name: l.name,
+        outstanding_balance: l.outstanding_balance ?? 0,
+        installment_frequency: l.installment_frequency,
+        annual_rate: l.annual_rate ?? 0,
+        installment_amount: l.installment_amount ?? 0,
+        remaining_term: l.remaining_term ?? 0,
+      }))
+  }
+
+  buildAssets(): ProfileTangibleAsset[] {
+    return this.assets
+      .filter((a) => a.name.trim().length > 0)
+      .map((a) => ({
+        id: a.id,
+        name: a.name,
+        value: a.value ?? 0,
+        status: a.status,
+        outstanding_balance: a.status === 'financed' ? (a.outstanding_balance ?? 0) : undefined,
+        installment_frequency: a.status === 'financed' ? a.installment_frequency : undefined,
+        annual_rate: a.status === 'financed' ? (a.annual_rate ?? 0) : undefined,
+        installment_amount: a.status === 'financed' ? (a.installment_amount ?? 0) : undefined,
+        remaining_term: a.status === 'financed' ? (a.remaining_term ?? 0) : undefined,
+      }))
+  }
+
+  // --- Commit a step's slice to the profile (called on Continue) ---
+  commitProfile(): void {
+    const updates: Record<string, string | undefined> = {
+      name: this.name.trim(),
+      location: this.location || undefined,
+      currency: this.currency || undefined,
+    }
+    if (this.birthYear !== '' && this.birthMonth !== '') {
+      const date = new Date(Number(this.birthYear), Number(this.birthMonth), 1)
+      updates.birth_date = date.toISOString().split('T')[0]
+    }
+    appStore.updateProfile(updates)
+  }
+
+  commitOverview(): void {
+    appStore.updateProfile({
+      cash_amount: this.cashAmount,
+      has_investments: this.hasInvestments,
+      has_tangible_assets: this.hasTangibleAssets,
+      has_liabilities: this.hasLiabilities,
+    })
+  }
+
+  commitIncomes(): void {
+    appStore.updateProfile({ incomes: this.buildIncomes() })
+  }
+
+  commitExpenses(): void {
+    appStore.updateProfile({ expenses: this.buildExpenses() })
+  }
+
+  commitInvestments(): void {
+    const data = this.buildInvestments()
+    appStore.updateProfile({ investments: data, has_investments: data.length > 0 })
+  }
+
+  commitLiabilities(): void {
+    const data = this.buildLiabilities()
+    appStore.updateProfile({ liabilities: data, has_liabilities: data.length > 0 })
+  }
+
+  commitAssets(): void {
+    const data = this.buildAssets()
+    appStore.updateProfile({ tangible_assets: data, has_tangible_assets: data.length > 0 })
+  }
+
+  /** Whether any step's draft has diverged from what's committed to the profile. */
+  get dirty(): boolean {
+    const p = appStore.profile
+    const builtBirth =
+      this.birthYear !== '' && this.birthMonth !== ''
+        ? new Date(Number(this.birthYear), Number(this.birthMonth), 1).toISOString().split('T')[0]
+        : undefined
+    return (
+      this.name.trim() !== p.name ||
+      (this.location || undefined) !== p.location ||
+      (this.currency || undefined) !== p.currency ||
+      builtBirth !== p.birth_date ||
+      this.cashAmount !== p.cash_amount ||
+      this.hasInvestments !== (p.has_investments ?? false) ||
+      this.hasTangibleAssets !== (p.has_tangible_assets ?? false) ||
+      this.hasLiabilities !== (p.has_liabilities ?? false) ||
+      stableStringify(this.buildIncomes()) !== stableStringify(p.incomes ?? []) ||
+      stableStringify(this.buildExpenses()) !== stableStringify(p.expenses ?? []) ||
+      stableStringify(this.buildInvestments()) !== stableStringify(p.investments ?? []) ||
+      stableStringify(this.buildLiabilities()) !== stableStringify(p.liabilities ?? []) ||
+      stableStringify(this.buildAssets()) !== stableStringify(p.tangible_assets ?? [])
+    )
+  }
+}
+
+function incomesToUI(stored: Income[]): IncomeUI[] {
+  return stored.map((inc) => ({
+    ...inc,
+    amount: inc.amount > 0 ? inc.amount : undefined,
+    showAdvanced: false,
+    editing: false,
+    editingName: false,
+  }))
+}
+
+function expensesToUI(stored: Expense[]): ExpenseUI[] {
+  return stored.map((exp) => ({
+    ...exp,
+    amount: exp.amount > 0 ? exp.amount : undefined,
+    showAdvanced: false,
+    editing: false,
+    editingName: false,
+  }))
+}
+
+function investmentsToUI(stored: ProfileInvestment[]): InvestmentUI[] {
+  return stored.map((inv) => ({
+    id: inv.id,
+    name: inv.name,
+    balance: inv.balance > 0 ? inv.balance : undefined,
+    apy: inv.apy > 0 ? inv.apy : undefined,
+    editing: false,
+    editingName: false,
+  }))
+}
+
+function liabilitiesToUI(stored: ProfileLiability[]): LiabilityUI[] {
+  return stored.map((l) => ({
+    id: l.id,
+    name: l.name,
+    outstanding_balance: l.outstanding_balance > 0 ? l.outstanding_balance : undefined,
+    installment_frequency: l.installment_frequency,
+    annual_rate: l.annual_rate > 0 ? l.annual_rate : undefined,
+    installment_amount: l.installment_amount > 0 ? l.installment_amount : undefined,
+    remaining_term: l.remaining_term > 0 ? l.remaining_term : undefined,
+    editing: false,
+    editingName: false,
+  }))
+}
+
+function assetsToUI(stored: ProfileTangibleAsset[]): AssetUI[] {
+  return stored.map((a) => ({
+    id: a.id,
+    name: a.name,
+    value: a.value > 0 ? a.value : undefined,
+    status: a.status,
+    outstanding_balance:
+      a.outstanding_balance !== undefined && a.outstanding_balance > 0
+        ? a.outstanding_balance
+        : undefined,
+    installment_frequency: a.installment_frequency ?? 'monthly',
+    annual_rate: a.annual_rate !== undefined && a.annual_rate > 0 ? a.annual_rate : undefined,
+    installment_amount:
+      a.installment_amount !== undefined && a.installment_amount > 0
+        ? a.installment_amount
+        : undefined,
+    remaining_term:
+      a.remaining_term !== undefined && a.remaining_term > 0 ? a.remaining_term : undefined,
+    editing: false,
+    editingName: false,
+  }))
+}
+
+export const onboardingDraft = new OnboardingDraftStore()

--- a/src/lib/stores/plan-draft.svelte.ts
+++ b/src/lib/stores/plan-draft.svelte.ts
@@ -1,0 +1,147 @@
+import { SvelteSet } from 'svelte/reactivity'
+
+import type { PlanEndType, PlanStartType, Profile } from '$lib/schemas'
+import { DEFAULT_CURRENCY } from '$lib/utils'
+
+/**
+ * Shared reactive draft for the multi-step add-plan flow.
+ *
+ * The `(add-plan)` layout stays mounted across the intro/details/data steps, so
+ * holding the draft in this module-level store preserves every form entry as the
+ * user navigates back and forth — no sessionStorage round-trip needed. The layout
+ * calls `reset()` when the flow is entered, so each fresh "Add plan" starts clean
+ * while in-flow navigation keeps the user's input.
+ */
+class PlanDraftStore {
+  // --- Details step ---
+  name = $state('')
+  notes = $state('')
+  startType = $state<PlanStartType>('now')
+  startYear = $state(String(new Date().getFullYear()))
+  startMonth = $state(String(new Date().getMonth()))
+  endType = $state<PlanEndType>('when_age_is')
+  endAge = $state<number | undefined>(85)
+  endYear = $state('')
+  endMonth = $state('')
+  currency = $state(DEFAULT_CURRENCY)
+  inflation = $state<number | undefined>(2)
+
+  // --- Data step ---
+  includeCash = $state(true)
+  includeInvestments = $state(true)
+  includeTangibleAssets = $state(true)
+  includeLiabilities = $state(true)
+  includeIncomes = $state(true)
+  includeExpenses = $state(true)
+  readonly selectedInvestmentIds = new SvelteSet<string>()
+  readonly selectedTangibleAssetIds = new SvelteSet<string>()
+  readonly selectedLiabilityIds = new SvelteSet<string>()
+  readonly selectedIncomeIds = new SvelteSet<string>()
+  readonly selectedExpenseIds = new SvelteSet<string>()
+
+  /** Serialized draft captured at the last reset, used to detect unsaved edits. */
+  #baseline = ''
+
+  /** Re-seed the whole draft from the current profile, for a fresh flow entry. */
+  reset(profile: Profile, portfolioCount: number): void {
+    const now = new Date()
+    this.name = `Plan ${portfolioCount + 1}`
+    this.notes = ''
+    this.startType = 'now'
+    this.startYear = String(now.getFullYear())
+    this.startMonth = String(now.getMonth())
+    this.endType = 'when_age_is'
+    this.endAge = 85
+    this.endYear = ''
+    this.endMonth = ''
+    this.currency = profile.currency ?? DEFAULT_CURRENCY
+    this.inflation = 2
+    this.selectAll(profile)
+    this.#baseline = this.#serialize()
+  }
+
+  /** Whether the draft has diverged from its freshly-reset defaults. */
+  get dirty(): boolean {
+    return this.#serialize() !== this.#baseline
+  }
+
+  #serialize(): string {
+    return JSON.stringify({
+      name: this.name,
+      notes: this.notes,
+      startType: this.startType,
+      startYear: this.startYear,
+      startMonth: this.startMonth,
+      endType: this.endType,
+      endAge: this.endAge,
+      endYear: this.endYear,
+      endMonth: this.endMonth,
+      currency: this.currency,
+      inflation: this.inflation,
+      includeCash: this.includeCash,
+      includeInvestments: this.includeInvestments,
+      includeTangibleAssets: this.includeTangibleAssets,
+      includeLiabilities: this.includeLiabilities,
+      includeIncomes: this.includeIncomes,
+      includeExpenses: this.includeExpenses,
+      selectedInvestmentIds: [...this.selectedInvestmentIds].sort(),
+      selectedTangibleAssetIds: [...this.selectedTangibleAssetIds].sort(),
+      selectedLiabilityIds: [...this.selectedLiabilityIds].sort(),
+      selectedIncomeIds: [...this.selectedIncomeIds].sort(),
+      selectedExpenseIds: [...this.selectedExpenseIds].sort(),
+    })
+  }
+
+  /** Include every category and select every item. */
+  selectAll(profile: Profile): void {
+    this.includeCash = true
+    this.includeInvestments = true
+    this.includeTangibleAssets = true
+    this.includeLiabilities = true
+    this.includeIncomes = true
+    this.includeExpenses = true
+    reseed(
+      this.selectedInvestmentIds,
+      (profile.investments ?? []).map((i) => i.id),
+    )
+    reseed(
+      this.selectedTangibleAssetIds,
+      (profile.tangible_assets ?? []).map((a) => a.id),
+    )
+    reseed(
+      this.selectedLiabilityIds,
+      (profile.liabilities ?? []).map((l) => l.id),
+    )
+    reseed(
+      this.selectedIncomeIds,
+      (profile.incomes ?? []).map((i) => i.id),
+    )
+    reseed(
+      this.selectedExpenseIds,
+      (profile.expenses ?? []).map((e) => e.id),
+    )
+  }
+
+  /** Exclude every category and clear all item selections. */
+  deselectAll(): void {
+    this.includeCash = false
+    this.includeInvestments = false
+    this.includeTangibleAssets = false
+    this.includeLiabilities = false
+    this.includeIncomes = false
+    this.includeExpenses = false
+    this.selectedInvestmentIds.clear()
+    this.selectedTangibleAssetIds.clear()
+    this.selectedLiabilityIds.clear()
+    this.selectedIncomeIds.clear()
+    this.selectedExpenseIds.clear()
+  }
+}
+
+/** Re-seed a SvelteSet in place from an array of ids. */
+function reseed(set: SvelteSet<string>, ids: string[]): void {
+  set.clear()
+  for (const id of ids) set.add(id)
+}
+
+export const planDraftStore = new PlanDraftStore()

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -125,3 +125,23 @@ export function formatLastUpdated(ms: number, locale: string | null | undefined)
   const d = ms > 0 ? new Date(ms) : new Date()
   return d.toLocaleDateString(locale ?? undefined)
 }
+
+/**
+ * JSON.stringify with object keys sorted recursively, so two structurally-equal
+ * values serialize identically regardless of key insertion order. Array order is
+ * preserved (it is significant). Useful for cheap deep-equality comparisons.
+ */
+export function stableStringify(value: unknown): string {
+  return JSON.stringify(value, (_key, val) => {
+    if (val && typeof val === 'object' && !Array.isArray(val)) {
+      const record = val as Record<string, unknown>
+      return Object.keys(record)
+        .sort()
+        .reduce<Record<string, unknown>>((acc, key) => {
+          acc[key] = record[key]
+          return acc
+        }, {})
+    }
+    return val
+  })
+}

--- a/src/routes/(add-plan)/+layout.svelte
+++ b/src/routes/(add-plan)/+layout.svelte
@@ -7,13 +7,28 @@
   import { page } from '$app/state'
 
   import { getAddPlanSteps } from '$lib/add-plan-steps'
+  import LeaveConfirmDialog from '$lib/components/leave-confirm-dialog.svelte'
   import ThemeSwitcher from '$lib/components/theme-switcher.svelte'
   import { Button } from '$lib/components/ui/button'
   import { Progress } from '$lib/components/ui/progress'
   import routes from '$lib/routes'
   import { appStore } from '$lib/stores/app.svelte'
+  import { leaveGuard } from '$lib/stores/leave-guard.svelte'
+  import { planDraftStore } from '$lib/stores/plan-draft.svelte'
 
   let { children } = $props()
+
+  // This layout stays mounted for the whole add-plan flow, so it owns the draft
+  // lifecycle: seed a fresh draft when the flow is entered. In-flow navigation
+  // between steps keeps the layout mounted, so the user's entries are preserved;
+  // leaving and re-entering re-mounts the layout and starts clean.
+  planDraftStore.reset(appStore.profile, appStore.portfolios.length)
+
+  // Warn before abandoning the flow (via the X or browser back) once the draft
+  // has diverged from its defaults. Creating the plan navigates with goto(), so
+  // it is never intercepted.
+  leaveGuard.guard('(add-plan)')
+  leaveGuard.setDirtyCheck(() => planDraftStore.dirty)
 
   const steps = $derived(getAddPlanSteps(appStore.profile))
   const totalSteps = $derived(steps.length)
@@ -44,3 +59,5 @@
     {@render children()}
   </main>
 </div>
+
+<LeaveConfirmDialog />

--- a/src/routes/(add-plan)/plan/add/data/+page.svelte
+++ b/src/routes/(add-plan)/plan/add/data/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { _ } from 'svelte-i18n'
-  import { SvelteSet } from 'svelte/reactivity'
+  import type { SvelteSet } from 'svelte/reactivity'
 
   import { ArrowRight } from '@lucide/svelte'
 
@@ -12,25 +12,10 @@
   import { Checkbox } from '$lib/components/ui/checkbox'
   import { Label } from '$lib/components/ui/label'
   import { Separator } from '$lib/components/ui/separator'
+  import { buildPlanCreationFields } from '$lib/plan-draft'
   import routes from '$lib/routes'
   import { appStore } from '$lib/stores/app.svelte'
-
-  // State for included items - all checked by default
-  let includeCash = $state(true)
-  let includeInvestments = $state(true)
-  let includeTangibleAssets = $state(true)
-  let includeLiabilities = $state(true)
-  let includeIncomes = $state(true)
-  let includeExpenses = $state(true)
-
-  // Individual item selections (SvelteSet is already reactive, no $state needed)
-  let selectedInvestmentIds = new SvelteSet((appStore.profile.investments ?? []).map((i) => i.id))
-  let selectedTangibleAssetIds = new SvelteSet(
-    (appStore.profile.tangible_assets ?? []).map((a) => a.id),
-  )
-  let selectedLiabilityIds = new SvelteSet((appStore.profile.liabilities ?? []).map((l) => l.id))
-  let selectedIncomeIds = new SvelteSet((appStore.profile.incomes ?? []).map((i) => i.id))
-  let selectedExpenseIds = new SvelteSet((appStore.profile.expenses ?? []).map((e) => e.id))
+  import { planDraftStore as draft } from '$lib/stores/plan-draft.svelte'
 
   // Helper to toggle individual item (mutates the set directly since SvelteSet is reactive)
   function toggleItem(set: SvelteSet<string>, id: string): void {
@@ -51,48 +36,13 @@
 
   // Check if all items are selected
   const allSelected = $derived(
-    includeCash &&
-      includeInvestments &&
-      includeTangibleAssets &&
-      includeLiabilities &&
-      includeIncomes &&
-      includeExpenses,
+    draft.includeCash &&
+      draft.includeInvestments &&
+      draft.includeTangibleAssets &&
+      draft.includeLiabilities &&
+      draft.includeIncomes &&
+      draft.includeExpenses,
   )
-
-  function selectAll() {
-    includeCash = true
-    includeInvestments = true
-    includeTangibleAssets = true
-    includeLiabilities = true
-    includeIncomes = true
-    includeExpenses = true
-    // Clear and refill SvelteSet (mutate in place)
-    selectedInvestmentIds.clear()
-    for (const i of appStore.profile.investments ?? []) selectedInvestmentIds.add(i.id)
-    selectedTangibleAssetIds.clear()
-    for (const a of appStore.profile.tangible_assets ?? []) selectedTangibleAssetIds.add(a.id)
-    selectedLiabilityIds.clear()
-    for (const l of appStore.profile.liabilities ?? []) selectedLiabilityIds.add(l.id)
-    selectedIncomeIds.clear()
-    for (const i of appStore.profile.incomes ?? []) selectedIncomeIds.add(i.id)
-    selectedExpenseIds.clear()
-    for (const e of appStore.profile.expenses ?? []) selectedExpenseIds.add(e.id)
-  }
-
-  function deselectAll() {
-    includeCash = false
-    includeInvestments = false
-    includeTangibleAssets = false
-    includeLiabilities = false
-    includeIncomes = false
-    includeExpenses = false
-    // Clear all SvelteSet (mutate in place)
-    selectedInvestmentIds.clear()
-    selectedTangibleAssetIds.clear()
-    selectedLiabilityIds.clear()
-    selectedIncomeIds.clear()
-    selectedExpenseIds.clear()
-  }
 
   function handleBack() {
     // URL is already resolved by getPrevAddPlanStepUrl
@@ -101,52 +51,27 @@
   }
 
   function handleCreatePlan() {
-    // Load plan details from sessionStorage
-    const draftStr = sessionStorage.getItem('kalkul-plan-draft')
-    if (!draftStr) {
-      // Fallback if no draft
-      goto(resolve(routes.HOME))
-      return
-    }
-
-    const draft = JSON.parse(draftStr) as {
-      name: string
-      notes?: string
-      currency: string
-      start_date: string
-      end_date: string
-      inflation_rate: number
-    }
-
-    // Create the portfolio with included references
+    // Create the portfolio with included references from the shared draft.
     // When category is checked: include all items; when unchecked: include only selected items
     const portfolioId = appStore.addPortfolio({
-      name: draft.name,
-      notes: draft.notes,
-      currency: draft.currency,
-      start_date: draft.start_date,
-      end_date: draft.end_date,
-      inflation_rate: draft.inflation_rate,
-      include_cash: includeCash,
-      included_investment_ids: includeInvestments
+      ...buildPlanCreationFields(draft, appStore.profile.birthDate),
+      include_cash: draft.includeCash,
+      included_investment_ids: draft.includeInvestments
         ? (appStore.profile.investments ?? []).map((i) => i.id)
-        : Array.from(selectedInvestmentIds),
-      included_tangible_asset_ids: includeTangibleAssets
+        : Array.from(draft.selectedInvestmentIds),
+      included_tangible_asset_ids: draft.includeTangibleAssets
         ? (appStore.profile.tangible_assets ?? []).map((a) => a.id)
-        : Array.from(selectedTangibleAssetIds),
-      included_liability_ids: includeLiabilities
+        : Array.from(draft.selectedTangibleAssetIds),
+      included_liability_ids: draft.includeLiabilities
         ? (appStore.profile.liabilities ?? []).map((l) => l.id)
-        : Array.from(selectedLiabilityIds),
-      included_income_ids: includeIncomes
+        : Array.from(draft.selectedLiabilityIds),
+      included_income_ids: draft.includeIncomes
         ? (appStore.profile.incomes ?? []).map((i) => i.id)
-        : Array.from(selectedIncomeIds),
-      included_expense_ids: includeExpenses
+        : Array.from(draft.selectedIncomeIds),
+      included_expense_ids: draft.includeExpenses
         ? (appStore.profile.expenses ?? []).map((e) => e.id)
-        : Array.from(selectedExpenseIds),
+        : Array.from(draft.selectedExpenseIds),
     })
-
-    // Clean up
-    sessionStorage.removeItem('kalkul-plan-draft')
 
     // Navigate to the new plan page
     goto(resolve(`${routes.PLAN_VIEW}/${portfolioId}`))
@@ -164,7 +89,7 @@
     <!-- Include current cash -->
     {#if hasCash}
       <div class="flex items-center gap-2">
-        <Checkbox id="include-cash" bind:checked={includeCash} />
+        <Checkbox id="include-cash" bind:checked={draft.includeCash} />
         <Label for="include-cash" class="cursor-pointer text-sm font-medium">
           {$_('page.addPlan.data.includeCash')}
         </Label>
@@ -175,12 +100,12 @@
     {#if hasInvestments}
       <div class="flex flex-col gap-2">
         <div class="flex items-center gap-2">
-          <Checkbox id="include-investments" bind:checked={includeInvestments} />
+          <Checkbox id="include-investments" bind:checked={draft.includeInvestments} />
           <Label for="include-investments" class="cursor-pointer text-sm font-medium">
             {$_('page.addPlan.data.includeInvestments')}
           </Label>
         </div>
-        {#if !includeInvestments}
+        {#if !draft.includeInvestments}
           <div class="ml-2 flex gap-2">
             <Separator orientation="vertical" class="h-auto" />
             <div class="flex flex-col gap-2 py-1">
@@ -188,8 +113,8 @@
                 <div class="flex items-center gap-2">
                   <Checkbox
                     id={`inv-${investment.id}`}
-                    checked={selectedInvestmentIds.has(investment.id)}
-                    onCheckedChange={() => toggleItem(selectedInvestmentIds, investment.id)}
+                    checked={draft.selectedInvestmentIds.has(investment.id)}
+                    onCheckedChange={() => toggleItem(draft.selectedInvestmentIds, investment.id)}
                   />
                   <Label for={`inv-${investment.id}`} class="cursor-pointer text-sm">
                     {investment.name}
@@ -206,12 +131,12 @@
     {#if hasTangibleAssets}
       <div class="flex flex-col gap-2">
         <div class="flex items-center gap-2">
-          <Checkbox id="include-tangible-assets" bind:checked={includeTangibleAssets} />
+          <Checkbox id="include-tangible-assets" bind:checked={draft.includeTangibleAssets} />
           <Label for="include-tangible-assets" class="cursor-pointer text-sm font-medium">
             {$_('page.addPlan.data.includeTangibleAssets')}
           </Label>
         </div>
-        {#if !includeTangibleAssets}
+        {#if !draft.includeTangibleAssets}
           <div class="ml-2 flex gap-2">
             <Separator orientation="vertical" class="h-auto" />
             <div class="flex flex-col gap-2 py-1">
@@ -219,8 +144,8 @@
                 <div class="flex items-center gap-2">
                   <Checkbox
                     id={`asset-${asset.id}`}
-                    checked={selectedTangibleAssetIds.has(asset.id)}
-                    onCheckedChange={() => toggleItem(selectedTangibleAssetIds, asset.id)}
+                    checked={draft.selectedTangibleAssetIds.has(asset.id)}
+                    onCheckedChange={() => toggleItem(draft.selectedTangibleAssetIds, asset.id)}
                   />
                   <Label for={`asset-${asset.id}`} class="cursor-pointer text-sm">
                     {asset.name}
@@ -237,12 +162,12 @@
     {#if hasLiabilities}
       <div class="flex flex-col gap-2">
         <div class="flex items-center gap-2">
-          <Checkbox id="include-liabilities" bind:checked={includeLiabilities} />
+          <Checkbox id="include-liabilities" bind:checked={draft.includeLiabilities} />
           <Label for="include-liabilities" class="cursor-pointer text-sm font-medium">
             {$_('page.addPlan.data.includeLiabilities')}
           </Label>
         </div>
-        {#if !includeLiabilities}
+        {#if !draft.includeLiabilities}
           <div class="ml-2 flex gap-2">
             <Separator orientation="vertical" class="h-auto" />
             <div class="flex flex-col gap-2 py-1">
@@ -250,8 +175,8 @@
                 <div class="flex items-center gap-2">
                   <Checkbox
                     id={`liability-${liability.id}`}
-                    checked={selectedLiabilityIds.has(liability.id)}
-                    onCheckedChange={() => toggleItem(selectedLiabilityIds, liability.id)}
+                    checked={draft.selectedLiabilityIds.has(liability.id)}
+                    onCheckedChange={() => toggleItem(draft.selectedLiabilityIds, liability.id)}
                   />
                   <Label for={`liability-${liability.id}`} class="cursor-pointer text-sm">
                     {liability.name}
@@ -268,12 +193,12 @@
     {#if hasIncomes}
       <div class="flex flex-col gap-2">
         <div class="flex items-center gap-2">
-          <Checkbox id="include-incomes" bind:checked={includeIncomes} />
+          <Checkbox id="include-incomes" bind:checked={draft.includeIncomes} />
           <Label for="include-incomes" class="cursor-pointer text-sm font-medium">
             {$_('page.addPlan.data.includeIncomes')}
           </Label>
         </div>
-        {#if !includeIncomes}
+        {#if !draft.includeIncomes}
           <div class="ml-2 flex gap-2">
             <Separator orientation="vertical" class="h-auto" />
             <div class="flex flex-col gap-2 py-1">
@@ -281,8 +206,8 @@
                 <div class="flex items-center gap-2">
                   <Checkbox
                     id={`income-${income.id}`}
-                    checked={selectedIncomeIds.has(income.id)}
-                    onCheckedChange={() => toggleItem(selectedIncomeIds, income.id)}
+                    checked={draft.selectedIncomeIds.has(income.id)}
+                    onCheckedChange={() => toggleItem(draft.selectedIncomeIds, income.id)}
                   />
                   <Label for={`income-${income.id}`} class="cursor-pointer text-sm">
                     {income.name}
@@ -299,12 +224,12 @@
     {#if hasExpenses}
       <div class="flex flex-col gap-2">
         <div class="flex items-center gap-2">
-          <Checkbox id="include-expenses" bind:checked={includeExpenses} />
+          <Checkbox id="include-expenses" bind:checked={draft.includeExpenses} />
           <Label for="include-expenses" class="cursor-pointer text-sm font-medium">
             {$_('page.addPlan.data.includeExpenses')}
           </Label>
         </div>
-        {#if !includeExpenses}
+        {#if !draft.includeExpenses}
           <div class="ml-2 flex gap-2">
             <Separator orientation="vertical" class="h-auto" />
             <div class="flex flex-col gap-2 py-1">
@@ -312,8 +237,8 @@
                 <div class="flex items-center gap-2">
                   <Checkbox
                     id={`expense-${expense.id}`}
-                    checked={selectedExpenseIds.has(expense.id)}
-                    onCheckedChange={() => toggleItem(selectedExpenseIds, expense.id)}
+                    checked={draft.selectedExpenseIds.has(expense.id)}
+                    onCheckedChange={() => toggleItem(draft.selectedExpenseIds, expense.id)}
                   />
                   <Label for={`expense-${expense.id}`} class="cursor-pointer text-sm">
                     {expense.name}
@@ -329,10 +254,20 @@
 
   <!-- Select all / Deselect all buttons -->
   <div class="flex items-center gap-2">
-    <Button variant="secondary" size="sm" onclick={selectAll} disabled={allSelected}>
+    <Button
+      variant="secondary"
+      size="sm"
+      onclick={() => draft.selectAll(appStore.profile)}
+      disabled={allSelected}
+    >
       {$_('page.addPlan.data.selectAll')}
     </Button>
-    <Button variant="secondary" size="sm" onclick={deselectAll} disabled={!allSelected}>
+    <Button
+      variant="secondary"
+      size="sm"
+      onclick={() => draft.deselectAll()}
+      disabled={!allSelected}
+    >
       {$_('page.addPlan.data.deselectAll')}
     </Button>
   </div>

--- a/src/routes/(add-plan)/plan/add/details/+page.svelte
+++ b/src/routes/(add-plan)/plan/add/details/+page.svelte
@@ -5,7 +5,6 @@
 
   import { goto } from '$app/navigation'
 
-  import { formatDate } from '$lib/@snaha/kalkul-maths'
   import { getNextAddPlanStepUrl, getPrevAddPlanStepUrl } from '$lib/add-plan-steps'
   import SuffixedInput from '$lib/components/suffixed-input.svelte'
   import { Button } from '$lib/components/ui/button'
@@ -14,62 +13,17 @@
   import * as Select from '$lib/components/ui/select'
   import { Textarea } from '$lib/components/ui/textarea'
   import routes from '$lib/routes'
-  import type { PlanEndType, PlanStartType } from '$lib/schemas'
   import { appStore } from '$lib/stores/app.svelte'
-  import { CURRENCY_OPTIONS, DEFAULT_CURRENCY, getMonthOptions, getYearOptions } from '$lib/utils'
-
-  // Generate a default plan name based on existing portfolios
-  function getDefaultPlanName(): string {
-    const existingCount = appStore.portfolios.length
-    return `Plan ${existingCount + 1}`
-  }
-
-  let name = $state(getDefaultPlanName())
-  let notes = $state('')
-  let startType = $state<PlanStartType>('now')
-  let startYear = $state(String(new Date().getFullYear()))
-  let startMonth = $state(String(new Date().getMonth()))
-  let endType = $state<PlanEndType>('when_age_is')
-  let endAge = $state<number | undefined>(85)
-  let endYear = $state('')
-  let endMonth = $state('')
-  let currency = $state(appStore.profile.currency ?? DEFAULT_CURRENCY)
-  let inflation = $state<number | undefined>(2)
+  import { planDraftStore as draft } from '$lib/stores/plan-draft.svelte'
+  import { CURRENCY_OPTIONS, getMonthOptions, getYearOptions } from '$lib/utils'
 
   const years = getYearOptions()
   const months = $derived(getMonthOptions($locale ?? undefined))
 
-  // Calculate date from start of current month
-  function getStartDate(): string {
-    if (startType === 'now') {
-      const now = new Date()
-      return formatDate(new Date(now.getFullYear(), now.getMonth(), 1))
-    }
-    return formatDate(new Date(Number(startYear), Number(startMonth), 1))
-  }
-
-  // Calculate end date based on age or specific date
-  function getEndDate(): string {
-    if (endType === 'when_age_is' && endAge !== undefined) {
-      const birthDate = appStore.profile.birthDate
-      if (birthDate) {
-        return formatDate(new Date(birthDate.getFullYear() + endAge, birthDate.getMonth(), 1))
-      }
-      // Fallback: use start year + age
-      const startYearNum = startType === 'now' ? new Date().getFullYear() : Number(startYear)
-      return formatDate(new Date(startYearNum + endAge, 0, 1))
-    }
-    if (endYear && endMonth !== '') {
-      return formatDate(new Date(Number(endYear), Number(endMonth), 1))
-    }
-    // Fallback (unreachable due to canContinue validation)
-    return formatDate(new Date(new Date().getFullYear() + 30, 0, 1))
-  }
-
   let canContinue = $derived(
-    name.trim().length > 0 &&
-      inflation !== undefined &&
-      (endType === 'when_age_is' || (endYear !== '' && endMonth !== '')),
+    draft.name.trim().length > 0 &&
+      draft.inflation !== undefined &&
+      (draft.endType === 'when_age_is' || (draft.endYear !== '' && draft.endMonth !== '')),
   )
 
   function handleBack() {
@@ -79,16 +33,7 @@
   }
 
   function handleContinue() {
-    // Store plan details in sessionStorage for step 3
-    const planDetails = {
-      name: name.trim(),
-      notes: notes.trim() || undefined,
-      currency,
-      start_date: getStartDate(),
-      end_date: getEndDate(),
-      inflation_rate: (inflation ?? 2) / 100,
-    }
-    sessionStorage.setItem('kalkul-plan-draft', JSON.stringify(planDetails))
+    // The draft lives in the shared store, so just advance the step.
     // URL is already resolved by getNextAddPlanStepUrl
     // eslint-disable-next-line svelte/no-navigation-without-resolve
     goto(getNextAddPlanStepUrl(routes.PLAN_ADD_DETAILS, appStore.profile))
@@ -104,7 +49,7 @@
   <div class="flex flex-col gap-4">
     <div class="flex flex-col gap-2">
       <Label for="plan-name">{$_('page.addPlan.details.planName')}</Label>
-      <Input id="plan-name" bind:value={name} />
+      <Input id="plan-name" bind:value={draft.name} />
     </div>
 
     <div class="flex flex-col gap-2">
@@ -112,7 +57,7 @@
       <Textarea
         id="plan-notes"
         placeholder={$_('page.addPlan.details.notesPlaceholder')}
-        bind:value={notes}
+        bind:value={draft.notes}
         class="min-h-16 resize-none"
       />
     </div>
@@ -120,9 +65,9 @@
     <div class="flex items-end gap-2">
       <div class="flex flex-1 flex-col gap-2">
         <Label>{$_('page.addPlan.details.start')}</Label>
-        <Select.Root type="single" bind:value={startType}>
+        <Select.Root type="single" bind:value={draft.startType}>
           <Select.Trigger class="w-full">
-            {startType === 'now'
+            {draft.startType === 'now'
               ? $_('page.addPlan.details.startNow')
               : $_('page.addPlan.details.startAtDate')}
           </Select.Trigger>
@@ -132,11 +77,11 @@
           </Select.Content>
         </Select.Root>
       </div>
-      {#if startType === 'at_specific_date'}
+      {#if draft.startType === 'at_specific_date'}
         <div class="flex flex-1 items-end gap-2">
-          <Select.Root type="single" bind:value={startYear}>
+          <Select.Root type="single" bind:value={draft.startYear}>
             <Select.Trigger class="w-24">
-              {startYear}
+              {draft.startYear}
             </Select.Trigger>
             <Select.Content>
               {#each years as year (year)}
@@ -144,9 +89,9 @@
               {/each}
             </Select.Content>
           </Select.Root>
-          <Select.Root type="single" bind:value={startMonth}>
+          <Select.Root type="single" bind:value={draft.startMonth}>
             <Select.Trigger class="flex-1">
-              {months[Number(startMonth)]?.label ?? ''}
+              {months[Number(draft.startMonth)]?.label ?? ''}
             </Select.Trigger>
             <Select.Content>
               {#each months as month (month.value)}
@@ -161,9 +106,9 @@
     <div class="flex items-end gap-2">
       <div class="flex flex-1 flex-col gap-2">
         <Label>{$_('page.addPlan.details.end')}</Label>
-        <Select.Root type="single" bind:value={endType}>
+        <Select.Root type="single" bind:value={draft.endType}>
           <Select.Trigger class="w-full">
-            {endType === 'when_age_is'
+            {draft.endType === 'when_age_is'
               ? $_('page.addPlan.details.endWhenAgeIs')
               : $_('page.addPlan.details.endAtDate')}
           </Select.Trigger>
@@ -173,21 +118,21 @@
           </Select.Content>
         </Select.Root>
       </div>
-      {#if endType === 'when_age_is'}
+      {#if draft.endType === 'when_age_is'}
         <div class="flex flex-1">
           <SuffixedInput
-            value={endAge}
+            value={draft.endAge}
             suffix={$_('page.addPlan.details.yearsOld')}
             formatNumber={appStore.formatNumber}
-            onValueChange={(v) => (endAge = v)}
+            onValueChange={(v) => (draft.endAge = v)}
           />
         </div>
       {:else}
         <div class="flex flex-1 items-end gap-2">
-          <Select.Root type="single" bind:value={endYear}>
+          <Select.Root type="single" bind:value={draft.endYear}>
             <Select.Trigger class="w-24">
-              {#if endYear}
-                {endYear}
+              {#if draft.endYear}
+                {draft.endYear}
               {:else}
                 <span class="text-muted-foreground">{$_('page.setup.aboutYou.selectYear')}</span>
               {/if}
@@ -198,10 +143,10 @@
               {/each}
             </Select.Content>
           </Select.Root>
-          <Select.Root type="single" bind:value={endMonth}>
+          <Select.Root type="single" bind:value={draft.endMonth}>
             <Select.Trigger class="flex-1">
-              {#if endMonth !== ''}
-                {months[Number(endMonth)]?.label ?? ''}
+              {#if draft.endMonth !== ''}
+                {months[Number(draft.endMonth)]?.label ?? ''}
               {:else}
                 <span class="text-muted-foreground">{$_('page.setup.aboutYou.selectMonth')}</span>
               {/if}
@@ -219,9 +164,9 @@
     <div class="flex items-end gap-2">
       <div class="flex flex-1 flex-col gap-2">
         <Label>{$_('page.addPlan.details.currency')}</Label>
-        <Select.Root type="single" bind:value={currency}>
+        <Select.Root type="single" bind:value={draft.currency}>
           <Select.Trigger class="w-full">
-            {CURRENCY_OPTIONS.find((c) => c.value === currency)?.label ?? currency}
+            {CURRENCY_OPTIONS.find((c) => c.value === draft.currency)?.label ?? draft.currency}
           </Select.Trigger>
           <Select.Content>
             {#each CURRENCY_OPTIONS as cur (cur.value)}
@@ -233,10 +178,10 @@
       <div class="flex flex-1 flex-col gap-2">
         <Label>{$_('page.addPlan.details.inflation')}</Label>
         <SuffixedInput
-          value={inflation}
+          value={draft.inflation}
           suffix="%"
           formatNumber={appStore.formatNumber}
-          onValueChange={(v) => (inflation = v)}
+          onValueChange={(v) => (draft.inflation = v)}
         />
       </div>
     </div>

--- a/src/routes/(onboarding)/+layout.svelte
+++ b/src/routes/(onboarding)/+layout.svelte
@@ -6,14 +6,34 @@
   import { resolve } from '$app/paths'
   import { page } from '$app/state'
 
+  import LeaveConfirmDialog from '$lib/components/leave-confirm-dialog.svelte'
   import ThemeSwitcher from '$lib/components/theme-switcher.svelte'
   import { Button } from '$lib/components/ui/button'
   import { Progress } from '$lib/components/ui/progress'
   import { getOnboardingSteps } from '$lib/onboarding-steps'
   import routes from '$lib/routes'
   import { appStore } from '$lib/stores/app.svelte'
+  import { leaveGuard } from '$lib/stores/leave-guard.svelte'
+  import { onboardingDraft } from '$lib/stores/onboarding-draft.svelte'
 
   let { children } = $props()
+
+  // This layout stays mounted for the whole flow, so it owns the draft lifecycle:
+  // seed a fresh draft from the profile once data has loaded. In-flow navigation
+  // keeps the layout mounted, so the user's entries survive Back/Continue; leaving
+  // and re-entering re-mounts the layout and re-seeds from the profile.
+  let seeded = $state(false)
+  $effect(() => {
+    if (seeded || appStore.loading) return
+    onboardingDraft.reset()
+    seeded = true
+  })
+
+  // Warn before abandoning setup (via the X or browser back) once the draft has
+  // unsaved changes. The flow's own Continue/Back/Skip use goto() and are never
+  // intercepted.
+  leaveGuard.guard('(onboarding)')
+  leaveGuard.setDirtyCheck(() => seeded && onboardingDraft.dirty)
 
   const steps = $derived(getOnboardingSteps(appStore.profile))
   const totalSteps = $derived(steps.length)
@@ -44,3 +64,5 @@
     {@render children()}
   </main>
 </div>
+
+<LeaveConfirmDialog />

--- a/src/routes/(onboarding)/finances/edit/+page.svelte
+++ b/src/routes/(onboarding)/finances/edit/+page.svelte
@@ -13,38 +13,17 @@
   import { getNextStepUrl } from '$lib/onboarding-steps'
   import routes from '$lib/routes'
   import { appStore } from '$lib/stores/app.svelte'
-
-  let cashAmount = $state<number | undefined>(undefined)
-  let hasInvestments = $state(false)
-  let hasTangibleAssets = $state(false)
-  let hasLiabilities = $state(false)
-  let hydrated = $state(false)
-
-  $effect(() => {
-    if (hydrated || appStore.loading) return
-    const p = appStore.profile
-    cashAmount = p.cash_amount
-    hasInvestments = p.has_investments ?? false
-    hasTangibleAssets = p.has_tangible_assets ?? false
-    hasLiabilities = p.has_liabilities ?? false
-    hydrated = true
-  })
+  import { onboardingDraft as draft } from '$lib/stores/onboarding-draft.svelte'
 
   let canContinue = $derived(
-    (cashAmount ?? 0) > 0 || hasInvestments || hasTangibleAssets || hasLiabilities,
+    (draft.cashAmount ?? 0) > 0 ||
+      draft.hasInvestments ||
+      draft.hasTangibleAssets ||
+      draft.hasLiabilities,
   )
 
-  function saveData() {
-    appStore.updateProfile({
-      cash_amount: cashAmount,
-      has_investments: hasInvestments,
-      has_tangible_assets: hasTangibleAssets,
-      has_liabilities: hasLiabilities,
-    })
-  }
-
   function handleContinue() {
-    saveData()
+    draft.commitOverview()
     // eslint-disable-next-line svelte/no-navigation-without-resolve
     goto(getNextStepUrl(routes.FINANCES_EDIT, appStore.profile))
   }
@@ -73,11 +52,11 @@
     <Label for="setup-cash">{$_('page.setup.finances.cashLabel')}</Label>
     <SuffixedInput
       id="setup-cash"
-      value={cashAmount}
+      value={draft.cashAmount}
       suffix={appStore.profile.currencyOrDefault}
       formatNumber={appStore.formatNumber}
       onValueChange={(v) => {
-        cashAmount = v
+        draft.cashAmount = v
       }}
     />
     <p class="text-sm text-muted-foreground">
@@ -91,27 +70,27 @@
     </p>
 
     <CheckboxCard
-      checked={hasInvestments}
+      checked={draft.hasInvestments}
       onCheckedChange={(v) => {
-        hasInvestments = v
+        draft.hasInvestments = v
       }}
       title={$_('page.setup.finances.investments')}
       description={$_('page.setup.finances.investmentsDescription')}
     />
 
     <CheckboxCard
-      checked={hasTangibleAssets}
+      checked={draft.hasTangibleAssets}
       onCheckedChange={(v) => {
-        hasTangibleAssets = v
+        draft.hasTangibleAssets = v
       }}
       title={$_('page.setup.finances.tangibleAssets')}
       description={$_('page.setup.finances.tangibleAssetsDescription')}
     />
 
     <CheckboxCard
-      checked={hasLiabilities}
+      checked={draft.hasLiabilities}
       onCheckedChange={(v) => {
-        hasLiabilities = v
+        draft.hasLiabilities = v
       }}
       title={$_('page.setup.finances.liabilities')}
       description={$_('page.setup.finances.liabilitiesDescription')}

--- a/src/routes/(onboarding)/finances/edit/expenses/+page.svelte
+++ b/src/routes/(onboarding)/finances/edit/expenses/+page.svelte
@@ -10,16 +10,9 @@
   import { Button } from '$lib/components/ui/button'
   import { getNextStepUrl, getPrevStepUrl } from '$lib/onboarding-steps'
   import routes from '$lib/routes'
-  import type { Expense as ExpenseData } from '$lib/schemas'
   import { appStore } from '$lib/stores/app.svelte'
+  import { type ExpenseUI, onboardingDraft as draft } from '$lib/stores/onboarding-draft.svelte'
   import { calculateAge, getMonthOptions, getYearOptions } from '$lib/utils'
-
-  type ExpenseUI = Omit<ExpenseData, 'amount'> & {
-    amount: number | undefined
-    showAdvanced: boolean
-    editing: boolean
-    editingName: boolean
-  }
 
   const currentYear = new Date().getFullYear()
   const currentMonth = new Date().getMonth()
@@ -29,38 +22,14 @@
   const years = getYearOptions()
   let months = $derived(getMonthOptions($locale ?? undefined))
 
-  function storedToUI(stored: ExpenseData[]): ExpenseUI[] {
-    return stored.map((exp) => ({
-      ...exp,
-      amount: exp.amount > 0 ? exp.amount : undefined,
-      showAdvanced: false,
-      editing: false,
-      editingName: false,
-    }))
-  }
-
-  let expenses = $state<ExpenseUI[]>([])
-  let expenseCounter = $state(0)
-  let hydrated = $state(false)
-
-  $effect(() => {
-    if (hydrated || appStore.loading) return
-    const stored = appStore.profile.expenses
-    if (stored && stored.length > 0) {
-      expenses = storedToUI(stored)
-      expenseCounter = expenses.length
-    }
-    hydrated = true
-  })
-
-  let canContinue = $derived(expenses.some((e) => (e.amount ?? 0) > 0))
+  let canContinue = $derived(draft.expenses.some((e) => (e.amount ?? 0) > 0))
 
   function addExpense() {
-    expenseCounter++
-    for (const exp of expenses) exp.editing = false
-    expenses.push({
+    draft.expenseCounter++
+    for (const exp of draft.expenses) exp.editing = false
+    draft.expenses.push({
       id: crypto.randomUUID(),
-      name: $_('page.setup.expenses.defaultName', { values: { index: expenseCounter } }),
+      name: $_('page.setup.expenses.defaultName', { values: { index: draft.expenseCounter } }),
       amount: undefined,
       frequency: 'monthly',
       showAdvanced: false,
@@ -80,9 +49,9 @@
   }
 
   function duplicateExpense(expense: ExpenseUI) {
-    expenseCounter++
-    const idx = expenses.indexOf(expense)
-    expenses.splice(idx + 1, 0, {
+    draft.expenseCounter++
+    const idx = draft.expenses.indexOf(expense)
+    draft.expenses.splice(idx + 1, 0, {
       ...expense,
       id: crypto.randomUUID(),
       name: $_('page.setup.common.copySuffix', { values: { name: expense.name } }),
@@ -92,39 +61,14 @@
   }
 
   function deleteExpense(expense: ExpenseUI) {
-    const idx = expenses.indexOf(expense)
-    if (idx !== -1) expenses.splice(idx, 1)
+    const idx = draft.expenses.indexOf(expense)
+    if (idx !== -1) draft.expenses.splice(idx, 1)
   }
 
   let currencyLabel = $derived(appStore.profile.currencyOrDefault)
 
-  function saveExpenses() {
-    const data: ExpenseData[] = expenses
-      .filter((e) => e.name.trim().length > 0)
-      .map((e) => ({
-        id: e.id,
-        name: e.name,
-        amount: e.amount ?? 0,
-        frequency: e.frequency,
-        start: e.start,
-        start_year: e.start === 'at_specific_date' ? e.start_year : undefined,
-        start_month: e.start === 'at_specific_date' ? e.start_month : undefined,
-        start_age: e.start === 'when_age_is' ? e.start_age : undefined,
-        end: e.end,
-        end_year: e.end === 'at_specific_date' ? e.end_year : undefined,
-        end_month: e.end === 'at_specific_date' ? e.end_month : undefined,
-        end_age: e.end === 'when_age_is' ? e.end_age : undefined,
-        change_over_time: e.change_over_time,
-        change_percentage:
-          e.change_over_time === 'increase_yearly' || e.change_over_time === 'decrease_yearly'
-            ? (e.change_percentage ?? 0)
-            : undefined,
-      }))
-    appStore.updateProfile({ expenses: data })
-  }
-
   function handleContinue() {
-    saveExpenses()
+    draft.commitExpenses()
     // eslint-disable-next-line svelte/no-navigation-without-resolve
     goto(getNextStepUrl(routes.FINANCES_EDIT_EXPENSES, appStore.profile))
   }
@@ -151,7 +95,7 @@
   </div>
 
   <div class="flex w-full flex-col gap-4">
-    {#each expenses as expense (expense.id)}
+    {#each draft.expenses as expense (expense.id)}
       <CashFlowItemCard
         item={expense}
         suffix={currencyLabel}

--- a/src/routes/(onboarding)/finances/edit/income/+page.svelte
+++ b/src/routes/(onboarding)/finances/edit/income/+page.svelte
@@ -13,16 +13,9 @@
   import { Label } from '$lib/components/ui/label'
   import { getNextStepUrl, getPrevStepUrl } from '$lib/onboarding-steps'
   import routes from '$lib/routes'
-  import type { Income as IncomeData } from '$lib/schemas'
   import { appStore } from '$lib/stores/app.svelte'
+  import { type IncomeUI, onboardingDraft as draft } from '$lib/stores/onboarding-draft.svelte'
   import { calculateAge, getMonthOptions, getYearOptions } from '$lib/utils'
-
-  type IncomeUI = Omit<IncomeData, 'amount'> & {
-    amount: number | undefined
-    showAdvanced: boolean
-    editing: boolean
-    editingName: boolean
-  }
 
   const currentYear = new Date().getFullYear()
   const currentMonth = new Date().getMonth()
@@ -32,38 +25,14 @@
   const years = getYearOptions()
   let months = $derived(getMonthOptions($locale ?? undefined))
 
-  function storedToUI(stored: IncomeData[]): IncomeUI[] {
-    return stored.map((inc) => ({
-      ...inc,
-      amount: inc.amount > 0 ? inc.amount : undefined,
-      showAdvanced: false,
-      editing: false,
-      editingName: false,
-    }))
-  }
-
-  let incomes = $state<IncomeUI[]>([])
-  let incomeCounter = $state(0)
-  let hydrated = $state(false)
-
-  $effect(() => {
-    if (hydrated || appStore.loading) return
-    const stored = appStore.profile.incomes
-    if (stored && stored.length > 0) {
-      incomes = storedToUI(stored)
-      incomeCounter = incomes.length
-    }
-    hydrated = true
-  })
-
-  let canContinue = $derived(incomes.some((i) => (i.amount ?? 0) > 0))
+  let canContinue = $derived(draft.incomes.some((i) => (i.amount ?? 0) > 0))
 
   function addIncome() {
-    incomeCounter++
-    for (const inc of incomes) inc.editing = false
-    incomes.push({
+    draft.incomeCounter++
+    for (const inc of draft.incomes) inc.editing = false
+    draft.incomes.push({
       id: crypto.randomUUID(),
-      name: $_('page.setup.income.defaultName', { values: { index: incomeCounter } }),
+      name: $_('page.setup.income.defaultName', { values: { index: draft.incomeCounter } }),
       amount: undefined,
       frequency: 'monthly',
       showAdvanced: false,
@@ -85,9 +54,9 @@
   }
 
   function duplicateIncome(income: IncomeUI) {
-    incomeCounter++
-    const idx = incomes.indexOf(income)
-    incomes.splice(idx + 1, 0, {
+    draft.incomeCounter++
+    const idx = draft.incomes.indexOf(income)
+    draft.incomes.splice(idx + 1, 0, {
       ...income,
       id: crypto.randomUUID(),
       name: $_('page.setup.common.copySuffix', { values: { name: income.name } }),
@@ -97,41 +66,14 @@
   }
 
   function deleteIncome(income: IncomeUI) {
-    const idx = incomes.indexOf(income)
-    if (idx !== -1) incomes.splice(idx, 1)
+    const idx = draft.incomes.indexOf(income)
+    if (idx !== -1) draft.incomes.splice(idx, 1)
   }
 
   let currencyLabel = $derived(appStore.profile.currencyOrDefault)
 
-  function saveIncomes() {
-    const data: IncomeData[] = incomes
-      .filter((i) => i.name.trim().length > 0)
-      .map((i) => ({
-        id: i.id,
-        name: i.name,
-        amount: i.amount ?? 0,
-        frequency: i.frequency,
-        withhold_taxes: i.withhold_taxes,
-        tax_percentage: i.tax_percentage,
-        start: i.start,
-        start_year: i.start === 'at_specific_date' ? i.start_year : undefined,
-        start_month: i.start === 'at_specific_date' ? i.start_month : undefined,
-        start_age: i.start === 'when_age_is' ? i.start_age : undefined,
-        end: i.end,
-        end_year: i.end === 'at_specific_date' ? i.end_year : undefined,
-        end_month: i.end === 'at_specific_date' ? i.end_month : undefined,
-        end_age: i.end === 'when_age_is' ? i.end_age : undefined,
-        change_over_time: i.change_over_time,
-        change_percentage:
-          i.change_over_time === 'increase_yearly' || i.change_over_time === 'decrease_yearly'
-            ? (i.change_percentage ?? 0)
-            : undefined,
-      }))
-    appStore.updateProfile({ incomes: data })
-  }
-
   function handleContinue() {
-    saveIncomes()
+    draft.commitIncomes()
     // eslint-disable-next-line svelte/no-navigation-without-resolve
     goto(getNextStepUrl(routes.FINANCES_EDIT_INCOME, appStore.profile))
   }
@@ -158,7 +100,7 @@
   </div>
 
   <div class="flex w-full flex-col gap-4">
-    {#each incomes as income (income.id)}
+    {#each draft.incomes as income (income.id)}
       <CashFlowItemCard
         item={income}
         suffix={currencyLabel}

--- a/src/routes/(onboarding)/finances/edit/investments/+page.svelte
+++ b/src/routes/(onboarding)/finances/edit/investments/+page.svelte
@@ -14,54 +14,22 @@
   import { Switch } from '$lib/components/ui/switch'
   import { getNextStepUrl, getPrevStepUrl } from '$lib/onboarding-steps'
   import routes from '$lib/routes'
-  import type { ProfileInvestment } from '$lib/schemas'
   import { appStore } from '$lib/stores/app.svelte'
+  import { type InvestmentUI, onboardingDraft as draft } from '$lib/stores/onboarding-draft.svelte'
   import { notImplemented } from '$lib/utils'
 
-  interface InvestmentUI {
-    id: string
-    name: string
-    balance: number | undefined
-    apy: number | undefined
-    editing: boolean
-    editingName: boolean
-  }
-
-  function storedToUI(stored: ProfileInvestment[]): InvestmentUI[] {
-    return stored.map((inv) => ({
-      id: inv.id,
-      name: inv.name,
-      balance: inv.balance > 0 ? inv.balance : undefined,
-      apy: inv.apy > 0 ? inv.apy : undefined,
-      editing: false,
-      editingName: false,
-    }))
-  }
-
-  let investments = $state<InvestmentUI[]>([])
-  let investmentCounter = $state(0)
-  let hydrated = $state(false)
-
-  $effect(() => {
-    if (hydrated || appStore.loading) return
-    const stored = appStore.profile.investments
-    if (stored && stored.length > 0) {
-      investments = storedToUI(stored)
-      investmentCounter = investments.length
-    }
-    hydrated = true
-  })
-
-  let canContinue = $derived(investments.some((i) => (i.balance ?? 0) > 0))
+  let canContinue = $derived(draft.investments.some((i) => (i.balance ?? 0) > 0))
 
   let currencyLabel = $derived(appStore.profile.currencyOrDefault)
 
   function addInvestment() {
-    investmentCounter++
-    for (const inv of investments) inv.editing = false
-    investments.push({
+    draft.investmentCounter++
+    for (const inv of draft.investments) inv.editing = false
+    draft.investments.push({
       id: crypto.randomUUID(),
-      name: $_('page.setup.investments.defaultName', { values: { index: investmentCounter } }),
+      name: $_('page.setup.investments.defaultName', {
+        values: { index: draft.investmentCounter },
+      }),
       balance: undefined,
       apy: undefined,
       editing: true,
@@ -70,9 +38,9 @@
   }
 
   function duplicateInvestment(investment: InvestmentUI) {
-    investmentCounter++
-    const idx = investments.indexOf(investment)
-    investments.splice(idx + 1, 0, {
+    draft.investmentCounter++
+    const idx = draft.investments.indexOf(investment)
+    draft.investments.splice(idx + 1, 0, {
       ...investment,
       id: crypto.randomUUID(),
       name: $_('page.setup.common.copySuffix', { values: { name: investment.name } }),
@@ -82,8 +50,8 @@
   }
 
   function deleteInvestment(investment: InvestmentUI) {
-    const idx = investments.indexOf(investment)
-    if (idx !== -1) investments.splice(idx, 1)
+    const idx = draft.investments.indexOf(investment)
+    if (idx !== -1) draft.investments.splice(idx, 1)
   }
 
   function formatBalance(balance: number | undefined): string {
@@ -91,23 +59,8 @@
     return appStore.formatCurrency(balance)
   }
 
-  function saveInvestments() {
-    const data: ProfileInvestment[] = investments
-      .filter((i) => i.name.trim().length > 0)
-      .map((i) => ({
-        id: i.id,
-        name: i.name,
-        balance: i.balance ?? 0,
-        apy: i.apy ?? 0,
-      }))
-    appStore.updateProfile({
-      investments: data,
-      has_investments: data.length > 0,
-    })
-  }
-
   function handleContinue() {
-    saveInvestments()
+    draft.commitInvestments()
     // eslint-disable-next-line svelte/no-navigation-without-resolve
     goto(getNextStepUrl(routes.FINANCES_EDIT_INVESTMENTS, appStore.profile))
   }
@@ -134,7 +87,7 @@
   </div>
 
   <div class="flex w-full flex-col gap-4">
-    {#each investments as investment (investment.id)}
+    {#each draft.investments as investment (investment.id)}
       <EditableItemCard
         item={investment}
         collapsedValue={formatBalance(investment.balance)}

--- a/src/routes/(onboarding)/finances/edit/liabilities/+page.svelte
+++ b/src/routes/(onboarding)/finances/edit/liabilities/+page.svelte
@@ -15,60 +15,21 @@
   import { Switch } from '$lib/components/ui/switch'
   import { getNextStepUrl, getPrevStepUrl } from '$lib/onboarding-steps'
   import routes from '$lib/routes'
-  import type { Frequency, ProfileLiability } from '$lib/schemas'
+  import type { Frequency } from '$lib/schemas'
   import { appStore } from '$lib/stores/app.svelte'
+  import { type LiabilityUI, onboardingDraft as draft } from '$lib/stores/onboarding-draft.svelte'
   import { notImplemented } from '$lib/utils'
 
-  interface LiabilityUI {
-    id: string
-    name: string
-    outstanding_balance: number | undefined
-    installment_frequency: Frequency
-    annual_rate: number | undefined
-    installment_amount: number | undefined
-    remaining_term: number | undefined
-    editing: boolean
-    editingName: boolean
-  }
-
-  function storedToUI(stored: ProfileLiability[]): LiabilityUI[] {
-    return stored.map((l) => ({
-      id: l.id,
-      name: l.name,
-      outstanding_balance: l.outstanding_balance > 0 ? l.outstanding_balance : undefined,
-      installment_frequency: l.installment_frequency,
-      annual_rate: l.annual_rate > 0 ? l.annual_rate : undefined,
-      installment_amount: l.installment_amount > 0 ? l.installment_amount : undefined,
-      remaining_term: l.remaining_term > 0 ? l.remaining_term : undefined,
-      editing: false,
-      editingName: false,
-    }))
-  }
-
-  let liabilities = $state<LiabilityUI[]>([])
-  let liabilityCounter = $state(0)
-  let hydrated = $state(false)
-
-  $effect(() => {
-    if (hydrated || appStore.loading) return
-    const stored = appStore.profile.liabilities
-    if (stored && stored.length > 0) {
-      liabilities = storedToUI(stored)
-      liabilityCounter = liabilities.length
-    }
-    hydrated = true
-  })
-
-  let canContinue = $derived(liabilities.some((l) => (l.outstanding_balance ?? 0) > 0))
+  let canContinue = $derived(draft.liabilities.some((l) => (l.outstanding_balance ?? 0) > 0))
 
   let currencyLabel = $derived(appStore.profile.currencyOrDefault)
 
   function addLiability() {
-    liabilityCounter++
-    for (const l of liabilities) l.editing = false
-    liabilities.push({
+    draft.liabilityCounter++
+    for (const l of draft.liabilities) l.editing = false
+    draft.liabilities.push({
       id: crypto.randomUUID(),
-      name: $_('page.setup.liabilities.defaultName', { values: { index: liabilityCounter } }),
+      name: $_('page.setup.liabilities.defaultName', { values: { index: draft.liabilityCounter } }),
       outstanding_balance: undefined,
       installment_frequency: 'monthly',
       annual_rate: undefined,
@@ -80,9 +41,9 @@
   }
 
   function duplicateLiability(liability: LiabilityUI) {
-    liabilityCounter++
-    const idx = liabilities.indexOf(liability)
-    liabilities.splice(idx + 1, 0, {
+    draft.liabilityCounter++
+    const idx = draft.liabilities.indexOf(liability)
+    draft.liabilities.splice(idx + 1, 0, {
       ...liability,
       id: crypto.randomUUID(),
       name: $_('page.setup.common.copySuffix', { values: { name: liability.name } }),
@@ -92,8 +53,8 @@
   }
 
   function deleteLiability(liability: LiabilityUI) {
-    const idx = liabilities.indexOf(liability)
-    if (idx !== -1) liabilities.splice(idx, 1)
+    const idx = draft.liabilities.indexOf(liability)
+    if (idx !== -1) draft.liabilities.splice(idx, 1)
   }
 
   function formatBalance(val: number | undefined): string {
@@ -107,26 +68,8 @@
     return $_('page.setup.common.monthly')
   }
 
-  function saveLiabilities() {
-    const data: ProfileLiability[] = liabilities
-      .filter((l) => l.name.trim().length > 0)
-      .map((l) => ({
-        id: l.id,
-        name: l.name,
-        outstanding_balance: l.outstanding_balance ?? 0,
-        installment_frequency: l.installment_frequency,
-        annual_rate: l.annual_rate ?? 0,
-        installment_amount: l.installment_amount ?? 0,
-        remaining_term: l.remaining_term ?? 0,
-      }))
-    appStore.updateProfile({
-      liabilities: data,
-      has_liabilities: data.length > 0,
-    })
-  }
-
   function handleContinue() {
-    saveLiabilities()
+    draft.commitLiabilities()
     // eslint-disable-next-line svelte/no-navigation-without-resolve
     goto(getNextStepUrl(routes.FINANCES_EDIT_LIABILITIES, appStore.profile))
   }
@@ -153,7 +96,7 @@
   </div>
 
   <div class="flex w-full flex-col gap-4">
-    {#each liabilities as liability (liability.id)}
+    {#each draft.liabilities as liability (liability.id)}
       <EditableItemCard
         item={liability}
         collapsedValue={formatBalance(liability.outstanding_balance)}

--- a/src/routes/(onboarding)/finances/edit/tangible-assets/+page.svelte
+++ b/src/routes/(onboarding)/finances/edit/tangible-assets/+page.svelte
@@ -15,71 +15,21 @@
   import { Switch } from '$lib/components/ui/switch'
   import { getNextStepUrl, getPrevStepUrl } from '$lib/onboarding-steps'
   import routes from '$lib/routes'
-  import type { Frequency, ProfileTangibleAsset, TangibleAssetStatus } from '$lib/schemas'
+  import type { Frequency, TangibleAssetStatus } from '$lib/schemas'
   import { appStore } from '$lib/stores/app.svelte'
+  import { type AssetUI, onboardingDraft as draft } from '$lib/stores/onboarding-draft.svelte'
   import { notImplemented } from '$lib/utils'
 
-  interface AssetUI {
-    id: string
-    name: string
-    value: number | undefined
-    status: TangibleAssetStatus
-    outstanding_balance: number | undefined
-    installment_frequency: Frequency
-    annual_rate: number | undefined
-    installment_amount: number | undefined
-    remaining_term: number | undefined
-    editing: boolean
-    editingName: boolean
-  }
-
-  function storedToUI(stored: ProfileTangibleAsset[]): AssetUI[] {
-    return stored.map((a) => ({
-      id: a.id,
-      name: a.name,
-      value: a.value > 0 ? a.value : undefined,
-      status: a.status,
-      outstanding_balance:
-        a.outstanding_balance !== undefined && a.outstanding_balance > 0
-          ? a.outstanding_balance
-          : undefined,
-      installment_frequency: a.installment_frequency ?? 'monthly',
-      annual_rate: a.annual_rate !== undefined && a.annual_rate > 0 ? a.annual_rate : undefined,
-      installment_amount:
-        a.installment_amount !== undefined && a.installment_amount > 0
-          ? a.installment_amount
-          : undefined,
-      remaining_term:
-        a.remaining_term !== undefined && a.remaining_term > 0 ? a.remaining_term : undefined,
-      editing: false,
-      editingName: false,
-    }))
-  }
-
-  let assets = $state<AssetUI[]>([])
-  let assetCounter = $state(0)
-  let hydrated = $state(false)
-
-  $effect(() => {
-    if (hydrated || appStore.loading) return
-    const stored = appStore.profile.tangible_assets
-    if (stored && stored.length > 0) {
-      assets = storedToUI(stored)
-      assetCounter = assets.length
-    }
-    hydrated = true
-  })
-
-  let canContinue = $derived(assets.some((a) => (a.value ?? 0) > 0))
+  let canContinue = $derived(draft.assets.some((a) => (a.value ?? 0) > 0))
 
   let currencyLabel = $derived(appStore.profile.currencyOrDefault)
 
   function addAsset() {
-    assetCounter++
-    for (const a of assets) a.editing = false
-    assets.push({
+    draft.assetCounter++
+    for (const a of draft.assets) a.editing = false
+    draft.assets.push({
       id: crypto.randomUUID(),
-      name: $_('page.setup.tangibleAssets.defaultName', { values: { index: assetCounter } }),
+      name: $_('page.setup.tangibleAssets.defaultName', { values: { index: draft.assetCounter } }),
       value: undefined,
       status: 'fully_owned',
       outstanding_balance: undefined,
@@ -93,9 +43,9 @@
   }
 
   function duplicateAsset(asset: AssetUI) {
-    assetCounter++
-    const idx = assets.indexOf(asset)
-    assets.splice(idx + 1, 0, {
+    draft.assetCounter++
+    const idx = draft.assets.indexOf(asset)
+    draft.assets.splice(idx + 1, 0, {
       ...asset,
       id: crypto.randomUUID(),
       name: $_('page.setup.common.copySuffix', { values: { name: asset.name } }),
@@ -105,8 +55,8 @@
   }
 
   function deleteAsset(asset: AssetUI) {
-    const idx = assets.indexOf(asset)
-    if (idx !== -1) assets.splice(idx, 1)
+    const idx = draft.assets.indexOf(asset)
+    if (idx !== -1) draft.assets.splice(idx, 1)
   }
 
   function formatValue(val: number | undefined): string {
@@ -120,28 +70,8 @@
     return $_('page.setup.common.monthly')
   }
 
-  function saveAssets() {
-    const data: ProfileTangibleAsset[] = assets
-      .filter((a) => a.name.trim().length > 0)
-      .map((a) => ({
-        id: a.id,
-        name: a.name,
-        value: a.value ?? 0,
-        status: a.status,
-        outstanding_balance: a.status === 'financed' ? (a.outstanding_balance ?? 0) : undefined,
-        installment_frequency: a.status === 'financed' ? a.installment_frequency : undefined,
-        annual_rate: a.status === 'financed' ? (a.annual_rate ?? 0) : undefined,
-        installment_amount: a.status === 'financed' ? (a.installment_amount ?? 0) : undefined,
-        remaining_term: a.status === 'financed' ? (a.remaining_term ?? 0) : undefined,
-      }))
-    appStore.updateProfile({
-      tangible_assets: data,
-      has_tangible_assets: data.length > 0,
-    })
-  }
-
   function handleContinue() {
-    saveAssets()
+    draft.commitAssets()
     // eslint-disable-next-line svelte/no-navigation-without-resolve
     goto(getNextStepUrl(routes.FINANCES_EDIT_TANGIBLE_ASSETS, appStore.profile))
   }
@@ -168,7 +98,7 @@
   </div>
 
   <div class="flex w-full flex-col gap-4">
-    {#each assets as asset (asset.id)}
+    {#each draft.assets as asset (asset.id)}
       <EditableItemCard
         item={asset}
         collapsedValue={formatValue(asset.value)}

--- a/src/routes/(onboarding)/profile/+page.svelte
+++ b/src/routes/(onboarding)/profile/+page.svelte
@@ -11,34 +11,13 @@
   import { Label } from '$lib/components/ui/label'
   import * as Select from '$lib/components/ui/select'
   import routes from '$lib/routes'
-  import { appStore } from '$lib/stores/app.svelte'
+  import { onboardingDraft as draft } from '$lib/stores/onboarding-draft.svelte'
   import {
     CURRENCY_OPTIONS,
     DEFAULT_CURRENCY,
     getBirthYearOptions,
     getMonthOptions,
   } from '$lib/utils'
-
-  let name = $state('')
-  let birthYear = $state('')
-  let birthMonth = $state('')
-  let location = $state('')
-  let currency = $state('')
-  let hydrated = $state(false)
-
-  // Hydrate form state from the store exactly once, on first load.
-  $effect(() => {
-    if (hydrated || appStore.loading) return
-    const p = appStore.profile
-    name = p.name
-    if (p.location) location = p.location
-    if (p.currency) currency = p.currency
-    if (p.birthDate) {
-      birthYear = String(p.birthDate.getFullYear())
-      birthMonth = String(p.birthDate.getMonth())
-    }
-    hydrated = true
-  })
 
   const years = getBirthYearOptions()
   const months = getMonthOptions()
@@ -59,30 +38,21 @@
     { value: 'other', label: $_('common.countries.other') },
   ])
 
-  let userChangedCurrency = $state(false)
-
   $effect(() => {
-    if (location && !userChangedCurrency) {
-      const mapped = countryCurrencyMap[location]
+    if (draft.location && !draft.userChangedCurrency) {
+      const mapped = countryCurrencyMap[draft.location]
       if (mapped) {
-        currency = mapped
+        draft.currency = mapped
       }
     }
   })
 
-  let canContinue = $derived(name.trim().length > 0 && birthYear !== '' && birthMonth !== '')
+  let canContinue = $derived(
+    draft.name.trim().length > 0 && draft.birthYear !== '' && draft.birthMonth !== '',
+  )
 
   function handleContinue() {
-    const updates: Record<string, string | undefined> = {
-      name: name.trim(),
-      location: location || undefined,
-      currency: currency || undefined,
-    }
-    if (birthYear !== '' && birthMonth !== '') {
-      const date = new Date(Number(birthYear), Number(birthMonth), 1)
-      updates.birth_date = date.toISOString().split('T')[0]
-    }
-    appStore.updateProfile(updates)
+    draft.commitProfile()
     goto(resolve(routes.FINANCES_EDIT))
   }
 </script>
@@ -103,17 +73,17 @@
       <Input
         id="setup-name"
         placeholder={$_('page.setup.aboutYou.namePlaceholder')}
-        bind:value={name}
+        bind:value={draft.name}
       />
     </div>
 
     <div class="flex w-full items-end gap-2">
       <div class="flex flex-1 flex-col gap-2">
         <Label>{$_('page.setup.aboutYou.birthdate')}</Label>
-        <Select.Root type="single" bind:value={birthYear}>
+        <Select.Root type="single" bind:value={draft.birthYear}>
           <Select.Trigger class="w-full">
-            {#if birthYear}
-              {birthYear}
+            {#if draft.birthYear}
+              {draft.birthYear}
             {:else}
               <span class="text-muted-foreground">{$_('page.setup.aboutYou.selectYear')}</span>
             {/if}
@@ -126,10 +96,10 @@
         </Select.Root>
       </div>
       <div class="flex flex-1 flex-col gap-2">
-        <Select.Root type="single" bind:value={birthMonth}>
+        <Select.Root type="single" bind:value={draft.birthMonth}>
           <Select.Trigger class="w-full">
-            {#if birthMonth !== ''}
-              {months[Number(birthMonth)]?.label}
+            {#if draft.birthMonth !== ''}
+              {months[Number(draft.birthMonth)]?.label}
             {:else}
               <span class="text-muted-foreground">{$_('page.setup.aboutYou.selectMonth')}</span>
             {/if}
@@ -146,10 +116,10 @@
     <div class="flex w-full items-end gap-2">
       <div class="flex flex-1 flex-col gap-2">
         <Label>{$_('page.setup.aboutYou.location')}</Label>
-        <Select.Root type="single" bind:value={location}>
+        <Select.Root type="single" bind:value={draft.location}>
           <Select.Trigger class="w-full">
-            {#if location}
-              {countries.find((c) => c.value === location)?.label}
+            {#if draft.location}
+              {countries.find((c) => c.value === draft.location)?.label}
             {:else}
               <span class="text-muted-foreground">{$_('page.setup.aboutYou.selectCountry')}</span>
             {/if}
@@ -165,12 +135,12 @@
         <Label>{$_('common.currency')}</Label>
         <Select.Root
           type="single"
-          bind:value={currency}
-          onValueChange={() => (userChangedCurrency = true)}
+          bind:value={draft.currency}
+          onValueChange={() => (draft.userChangedCurrency = true)}
         >
           <Select.Trigger class="w-full">
-            {#if currency}
-              {CURRENCY_OPTIONS.find((c) => c.value === currency)?.label}
+            {#if draft.currency}
+              {CURRENCY_OPTIONS.find((c) => c.value === draft.currency)?.label}
             {:else}
               <span class="text-muted-foreground">{DEFAULT_CURRENCY}</span>
             {/if}


### PR DESCRIPTION
Fixes #76. Supersedes #85 (which used sessionStorage for add-plan only) with a store-based approach that also covers the onboarding wizard.

## Problem

Multi-step forms lost user input when navigating between steps:

- **Add-plan** (`/plan/add/...`) — navigating **back** wiped everything entered in the Details and Data steps. The draft was only written on Continue, with no re-hydration on mount.
- **Onboarding** (`(onboarding)/...`) — each step re-hydrated from the profile on every (re)mount, so any in-progress edits made *before* clicking Continue were lost when navigating Back.

A natural first instinct is SvelteKit **snapshots**, but they only restore on browser **back/forward** (popstate), not on the wizard's own `goto()`-based Back/Continue buttons — so they don't actually fix the in-app navigation case. (Verified empirically.)

## Fix

Both flows keep their in-progress state in a **shared module rune store** that lives as long as the flow's layout is mounted, so it survives `goto()` navigation between steps:

- **`src/lib/stores/plan-draft.svelte.ts`** — raw add-plan Details + Data selections; seeded on flow entry, committed when the plan is created. Pure date-derivation / field-building helpers live in **`src/lib/plan-draft.ts`** (unit-tested).
- **`src/lib/stores/onboarding-draft.svelte.ts`** — profile, finances overview, and the income/expense/investment/liability/asset rows (incl. transient editing UI state). Seeded from the profile on entry; committed slice-by-slice on each step's Continue.

Each flow layout seeds its store on entry (onboarding waits for the data load) and re-seeds on re-entry, so leaving and re-entering starts fresh.

## Leave confirmation

Leaving a flow with unsaved changes (the header **X** or browser back) now shows a confirmation dialog, gated on the store's `dirty` getter:

- Shared **`leave-guard.svelte.ts`** store + **`leave-confirm-dialog.svelte`** component, used by both flow layouts.
- The guard only intercepts `link`/`popstate` navigations that **leave the flow** — the wizard's own `goto()`-based Continue/Back/Skip and the post-create redirect are never intercepted, so they never false-prompt.
- Adds a `stableStringify` util for order-independent dirty comparison and `common.leaveConfirm` strings (`cs` + `en`).

## Net effect

20 files changed, **+1004 / −651**. The onboarding step pages shrink substantially (local `$state` + hydrate effects → store bindings).

## Verification

`pnpm check` (0 errors), `eslint`, `knip`, `check-locales`, and **322 unit tests** all pass. Verified live in the browser:

- ✅ In-app **Back → forward preserves in-progress edits** (the case snapshots failed)
- ✅ Continue commits to the profile / localStorage
- ✅ Dirty exit via X → dialog; **Leave** navigates away, **Stay** keeps you put
- ✅ Clean (non-dirty) exit → straight out, no dialog
- ✅ Re-entering a flow re-seeds from the profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)