### PR TITLE
fix: load store before render + remove per-plan currency

### DIFF
--- a/src/lib/@snaha/kalkul-maths/graph-data.test.ts
+++ b/src/lib/@snaha/kalkul-maths/graph-data.test.ts
@@ -236,7 +236,6 @@ describe('inflation-adjusted transactions on graph', () => {
   }
 
   const portfolio: Portfolio = {
-    currency: 'USD',
     end_date: '2030-12-31',
     id: 'test-portfolio-1',
     inflation_rate: 0.03,
@@ -414,7 +413,6 @@ describe('inflation-adjusted transactions on graph', () => {
   it('should use earliest transaction date as inflation baseline', () => {
     // Portfolio runs from 2025-2055 but first transaction is from 1997
     const portfolio: Portfolio = {
-      currency: 'EUR',
       end_date: '2055-01-13',
       id: 'test-portfolio-2',
       inflation_rate: 0.0225,
@@ -476,7 +474,6 @@ describe('inflation-adjusted transactions on graph', () => {
   it('should use portfolio start date when it is earlier than first transaction', () => {
     // Portfolio starts in 1990, first transaction is in 2000
     const portfolio: Portfolio = {
-      currency: 'USD',
       end_date: '2030-01-01',
       id: 'test-portfolio-3',
       inflation_rate: 0.05,
@@ -635,7 +632,6 @@ describe('per-investment caching', () => {
   const mockPortfolio: Portfolio = {
     id: 'test-portfolio-1',
     name: 'Test Portfolio',
-    currency: 'USD',
     start_date: '2024-01-01',
     end_date: '2024-12-31',
     inflation_rate: 0.03,

--- a/src/lib/locales/cs.json
+++ b/src/lib/locales/cs.json
@@ -22,7 +22,6 @@
         "endWhenAgeIs": "Když vám bude",
         "endAtDate": "K určitému datu...",
         "yearsOld": "Let",
-        "currency": "Měna",
         "inflation": "Inflace"
       },
       "data": {

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -22,7 +22,6 @@
         "endWhenAgeIs": "When your age is",
         "endAtDate": "At specific date...",
         "yearsOld": "Years old",
-        "currency": "Currency",
         "inflation": "Inflation"
       },
       "data": {

--- a/src/lib/plan-projection.test.ts
+++ b/src/lib/plan-projection.test.ts
@@ -16,7 +16,6 @@ function makePlan(overrides: Partial<PortfolioNested> = {}): PortfolioNested {
   return {
     id: 'plan-1',
     name: 'Test plan',
-    currency: 'CZK',
     start_date: '2025-01-01',
     end_date: '2030-01-01',
     inflation_rate: 0,

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -346,7 +346,6 @@ export const portfolioSchema = z.object({
   id: z.string(),
   name: z.string(),
   notes: z.string().optional(),
-  currency: z.string(),
   start_date: z.string(),
   end_date: z.string(),
   inflation_rate: z.number(),

--- a/src/lib/stores/portfolio-simulation.svelte.test.ts
+++ b/src/lib/stores/portfolio-simulation.svelte.test.ts
@@ -9,7 +9,6 @@ describe('withPortfolioSimulationStore', () => {
   const mockPortfolio: Portfolio = {
     id: 'test-portfolio-1',
     name: 'Test Portfolio',
-    currency: 'USD',
     start_date: '2024-01-01',
     end_date: '2024-12-31',
     inflation_rate: 0.03,

--- a/src/lib/stores/portfolio.svelte.ts
+++ b/src/lib/stores/portfolio.svelte.ts
@@ -32,7 +32,6 @@ export type PortfolioStore = Omit<PortfolioNested, 'investments' | 'goals'> & {
 export function withPortfolioStore(portfolio: PortfolioNested, app: AppParent): PortfolioStore {
   let id = $state(portfolio.id)
   let name = $state(portfolio.name)
-  let currency = $state(portfolio.currency)
   let start_date = $state(portfolio.start_date)
   let end_date = $state(portfolio.end_date)
   let inflation_rate = $state(portfolio.inflation_rate)
@@ -61,12 +60,6 @@ export function withPortfolioStore(portfolio: PortfolioNested, app: AppParent): 
     },
     set name(v) {
       name = v
-    },
-    get currency() {
-      return currency
-    },
-    set currency(v) {
-      currency = v
     },
     get start_date() {
       return start_date
@@ -246,7 +239,6 @@ export function withPortfolioStore(portfolio: PortfolioNested, app: AppParent): 
       return {
         id,
         name,
-        currency,
         start_date,
         end_date,
         inflation_rate,

--- a/src/routes/(add-plan)/plan/add/data/+page.svelte
+++ b/src/routes/(add-plan)/plan/add/data/+page.svelte
@@ -112,7 +112,6 @@
     const draft = JSON.parse(draftStr) as {
       name: string
       notes?: string
-      currency: string
       start_date: string
       end_date: string
       inflation_rate: number
@@ -123,7 +122,9 @@
     const portfolioId = appStore.addPortfolio({
       name: draft.name,
       notes: draft.notes,
-      currency: draft.currency,
+      // Per-plan currency isn't supported yet (no FX; formatters use the profile
+      // currency), so plans inherit the profile currency.
+      currency: appStore.profile.currencyOrDefault,
       start_date: draft.start_date,
       end_date: draft.end_date,
       inflation_rate: draft.inflation_rate,

--- a/src/routes/(add-plan)/plan/add/data/+page.svelte
+++ b/src/routes/(add-plan)/plan/add/data/+page.svelte
@@ -122,9 +122,6 @@
     const portfolioId = appStore.addPortfolio({
       name: draft.name,
       notes: draft.notes,
-      // Per-plan currency isn't supported yet (no FX; formatters use the profile
-      // currency), so plans inherit the profile currency.
-      currency: appStore.profile.currencyOrDefault,
       start_date: draft.start_date,
       end_date: draft.end_date,
       inflation_rate: draft.inflation_rate,

--- a/src/routes/(add-plan)/plan/add/details/+page.svelte
+++ b/src/routes/(add-plan)/plan/add/details/+page.svelte
@@ -33,11 +33,18 @@
   let endAge = $state<number | undefined>(85)
   let endYear = $state('')
   let endMonth = $state('')
-  // Writable $derived: tracks the profile currency once the store finishes loading
-  // (avoids a stale EUR default on reload/deep-link), while bind:value still lets the
-  // user override it — nothing here mutates profile.currency, so the override sticks.
-  let currency = $derived(appStore.profile.currency ?? DEFAULT_CURRENCY)
+  let currency = $state(DEFAULT_CURRENCY)
   let inflation = $state<number | undefined>(2)
+  let hydrated = $state(false)
+
+  // The store loads localStorage asynchronously, so profile.currency is undefined
+  // at component init. Copy it once load completes (avoids a stale EUR default on
+  // reload/deep-link); after that the user's bind:value selection is left alone.
+  $effect(() => {
+    if (hydrated || appStore.loading) return
+    if (appStore.profile.currency) currency = appStore.profile.currency
+    hydrated = true
+  })
 
   const years = getYearOptions()
   const months = $derived(getMonthOptions($locale ?? undefined))

--- a/src/routes/(add-plan)/plan/add/details/+page.svelte
+++ b/src/routes/(add-plan)/plan/add/details/+page.svelte
@@ -16,7 +16,7 @@
   import routes from '$lib/routes'
   import type { PlanEndType, PlanStartType } from '$lib/schemas'
   import { appStore } from '$lib/stores/app.svelte'
-  import { CURRENCY_OPTIONS, getMonthOptions, getYearOptions } from '$lib/utils'
+  import { getMonthOptions, getYearOptions } from '$lib/utils'
 
   // Generate a default plan name based on existing portfolios
   function getDefaultPlanName(): string {
@@ -33,10 +33,6 @@
   let endAge = $state<number | undefined>(85)
   let endYear = $state('')
   let endMonth = $state('')
-  // Per-plan currency isn't honored by the engine/formatters yet (no FX, display
-  // uses the profile currency), so the selector is shown read-only and the plan
-  // always inherits the profile currency.
-  const currency = $derived(appStore.profile.currencyOrDefault)
   let inflation = $state<number | undefined>(2)
 
   const years = getYearOptions()
@@ -96,7 +92,6 @@
     const planDetails = {
       name: name.trim(),
       notes: notes.trim() || undefined,
-      currency,
       start_date: getStartDate(),
       end_date: getEndDate(),
       inflation_rate: (inflation ?? 2) / 100,
@@ -183,20 +178,14 @@
       {/if}
     </div>
 
-    <div class="flex items-end gap-2">
-      <div class="flex flex-1 flex-col gap-2">
-        <Label>{$_('page.addPlan.details.currency')}</Label>
-        <SelectField value={currency} items={CURRENCY_OPTIONS} disabled />
-      </div>
-      <div class="flex flex-1 flex-col gap-2">
-        <Label>{$_('page.addPlan.details.inflation')}</Label>
-        <SuffixedInput
-          value={inflation}
-          suffix="%"
-          formatNumber={appStore.formatNumber}
-          onValueChange={(v) => (inflation = v)}
-        />
-      </div>
+    <div class="flex flex-col gap-2">
+      <Label>{$_('page.addPlan.details.inflation')}</Label>
+      <SuffixedInput
+        value={inflation}
+        suffix="%"
+        formatNumber={appStore.formatNumber}
+        onValueChange={(v) => (inflation = v)}
+      />
     </div>
   </div>
 

--- a/src/routes/(add-plan)/plan/add/details/+page.svelte
+++ b/src/routes/(add-plan)/plan/add/details/+page.svelte
@@ -33,7 +33,10 @@
   let endAge = $state<number | undefined>(85)
   let endYear = $state('')
   let endMonth = $state('')
-  let currency = $state(appStore.profile.currency ?? DEFAULT_CURRENCY)
+  // Writable $derived: tracks the profile currency once the store finishes loading
+  // (avoids a stale EUR default on reload/deep-link), while bind:value still lets the
+  // user override it — nothing here mutates profile.currency, so the override sticks.
+  let currency = $derived(appStore.profile.currency ?? DEFAULT_CURRENCY)
   let inflation = $state<number | undefined>(2)
 
   const years = getYearOptions()

--- a/src/routes/(add-plan)/plan/add/details/+page.svelte
+++ b/src/routes/(add-plan)/plan/add/details/+page.svelte
@@ -33,18 +33,8 @@
   let endAge = $state<number | undefined>(85)
   let endYear = $state('')
   let endMonth = $state('')
-  let currency = $state(DEFAULT_CURRENCY)
+  let currency = $state(appStore.profile.currency ?? DEFAULT_CURRENCY)
   let inflation = $state<number | undefined>(2)
-  let hydrated = $state(false)
-
-  // The store loads localStorage asynchronously, so profile.currency is undefined
-  // at component init. Copy it once load completes (avoids a stale EUR default on
-  // reload/deep-link); after that the user's bind:value selection is left alone.
-  $effect(() => {
-    if (hydrated || appStore.loading) return
-    if (appStore.profile.currency) currency = appStore.profile.currency
-    hydrated = true
-  })
 
   const years = getYearOptions()
   const months = $derived(getMonthOptions($locale ?? undefined))

--- a/src/routes/(add-plan)/plan/add/details/+page.svelte
+++ b/src/routes/(add-plan)/plan/add/details/+page.svelte
@@ -16,7 +16,7 @@
   import routes from '$lib/routes'
   import type { PlanEndType, PlanStartType } from '$lib/schemas'
   import { appStore } from '$lib/stores/app.svelte'
-  import { CURRENCY_OPTIONS, DEFAULT_CURRENCY, getMonthOptions, getYearOptions } from '$lib/utils'
+  import { CURRENCY_OPTIONS, getMonthOptions, getYearOptions } from '$lib/utils'
 
   // Generate a default plan name based on existing portfolios
   function getDefaultPlanName(): string {
@@ -33,7 +33,10 @@
   let endAge = $state<number | undefined>(85)
   let endYear = $state('')
   let endMonth = $state('')
-  let currency = $state(appStore.profile.currency ?? DEFAULT_CURRENCY)
+  // Per-plan currency isn't honored by the engine/formatters yet (no FX, display
+  // uses the profile currency), so the selector is shown read-only and the plan
+  // always inherits the profile currency.
+  const currency = $derived(appStore.profile.currencyOrDefault)
   let inflation = $state<number | undefined>(2)
 
   const years = getYearOptions()
@@ -183,7 +186,7 @@
     <div class="flex items-end gap-2">
       <div class="flex flex-1 flex-col gap-2">
         <Label>{$_('page.addPlan.details.currency')}</Label>
-        <SelectField bind:value={currency} items={CURRENCY_OPTIONS} />
+        <SelectField value={currency} items={CURRENCY_OPTIONS} disabled />
       </div>
       <div class="flex flex-1 flex-col gap-2">
         <Label>{$_('page.addPlan.details.inflation')}</Label>

--- a/src/routes/(onboarding)/finances/edit/+page.svelte
+++ b/src/routes/(onboarding)/finances/edit/+page.svelte
@@ -14,21 +14,13 @@
   import routes from '$lib/routes'
   import { appStore } from '$lib/stores/app.svelte'
 
-  let cashAmount = $state<number | undefined>(undefined)
-  let hasInvestments = $state(false)
-  let hasTangibleAssets = $state(false)
-  let hasLiabilities = $state(false)
-  let hydrated = $state(false)
-
-  $effect(() => {
-    if (hydrated || appStore.loading) return
-    const p = appStore.profile
-    cashAmount = p.cash_amount
-    hasInvestments = p.has_investments ?? false
-    hasTangibleAssets = p.has_tangible_assets ?? false
-    hasLiabilities = p.has_liabilities ?? false
-    hydrated = true
-  })
+  // The store is loaded before render (see +layout.ts), so the profile is
+  // already populated here — seed the form state directly.
+  const p = appStore.profile
+  let cashAmount = $state<number | undefined>(p.cash_amount)
+  let hasInvestments = $state(p.has_investments ?? false)
+  let hasTangibleAssets = $state(p.has_tangible_assets ?? false)
+  let hasLiabilities = $state(p.has_liabilities ?? false)
 
   let canContinue = $derived(
     (cashAmount ?? 0) > 0 || hasInvestments || hasTangibleAssets || hasLiabilities,

--- a/src/routes/(onboarding)/finances/edit/expenses/+page.svelte
+++ b/src/routes/(onboarding)/finances/edit/expenses/+page.svelte
@@ -39,19 +39,11 @@
     }))
   }
 
-  let expenses = $state<ExpenseUI[]>([])
-  let expenseCounter = $state(0)
-  let hydrated = $state(false)
-
-  $effect(() => {
-    if (hydrated || appStore.loading) return
-    const stored = appStore.profile.expenses
-    if (stored && stored.length > 0) {
-      expenses = storedToUI(stored)
-      expenseCounter = expenses.length
-    }
-    hydrated = true
-  })
+  // The store is loaded before render (see +layout.ts), so the profile is
+  // already populated here — seed the form state directly.
+  const initialExpenses = storedToUI(appStore.profile.expenses ?? [])
+  let expenses = $state<ExpenseUI[]>(initialExpenses)
+  let expenseCounter = $state(initialExpenses.length)
 
   let canContinue = $derived(expenses.some((e) => (e.amount ?? 0) > 0))
 

--- a/src/routes/(onboarding)/finances/edit/income/+page.svelte
+++ b/src/routes/(onboarding)/finances/edit/income/+page.svelte
@@ -42,19 +42,11 @@
     }))
   }
 
-  let incomes = $state<IncomeUI[]>([])
-  let incomeCounter = $state(0)
-  let hydrated = $state(false)
-
-  $effect(() => {
-    if (hydrated || appStore.loading) return
-    const stored = appStore.profile.incomes
-    if (stored && stored.length > 0) {
-      incomes = storedToUI(stored)
-      incomeCounter = incomes.length
-    }
-    hydrated = true
-  })
+  // The store is loaded before render (see +layout.ts), so the profile is
+  // already populated here — seed the form state directly.
+  const initialIncomes = storedToUI(appStore.profile.incomes ?? [])
+  let incomes = $state<IncomeUI[]>(initialIncomes)
+  let incomeCounter = $state(initialIncomes.length)
 
   let canContinue = $derived(incomes.some((i) => (i.amount ?? 0) > 0))
 

--- a/src/routes/(onboarding)/finances/edit/investments/+page.svelte
+++ b/src/routes/(onboarding)/finances/edit/investments/+page.svelte
@@ -38,19 +38,11 @@
     }))
   }
 
-  let investments = $state<InvestmentUI[]>([])
-  let investmentCounter = $state(0)
-  let hydrated = $state(false)
-
-  $effect(() => {
-    if (hydrated || appStore.loading) return
-    const stored = appStore.profile.investments
-    if (stored && stored.length > 0) {
-      investments = storedToUI(stored)
-      investmentCounter = investments.length
-    }
-    hydrated = true
-  })
+  // The store is loaded before render (see +layout.ts), so the profile is
+  // already populated here — seed the form state directly.
+  const initialInvestments = storedToUI(appStore.profile.investments ?? [])
+  let investments = $state<InvestmentUI[]>(initialInvestments)
+  let investmentCounter = $state(initialInvestments.length)
 
   let canContinue = $derived(investments.some((i) => (i.balance ?? 0) > 0))
 

--- a/src/routes/(onboarding)/finances/edit/liabilities/+page.svelte
+++ b/src/routes/(onboarding)/finances/edit/liabilities/+page.svelte
@@ -45,19 +45,11 @@
     }))
   }
 
-  let liabilities = $state<LiabilityUI[]>([])
-  let liabilityCounter = $state(0)
-  let hydrated = $state(false)
-
-  $effect(() => {
-    if (hydrated || appStore.loading) return
-    const stored = appStore.profile.liabilities
-    if (stored && stored.length > 0) {
-      liabilities = storedToUI(stored)
-      liabilityCounter = liabilities.length
-    }
-    hydrated = true
-  })
+  // The store is loaded before render (see +layout.ts), so the profile is
+  // already populated here — seed the form state directly.
+  const initialLiabilities = storedToUI(appStore.profile.liabilities ?? [])
+  let liabilities = $state<LiabilityUI[]>(initialLiabilities)
+  let liabilityCounter = $state(initialLiabilities.length)
 
   let canContinue = $derived(liabilities.some((l) => (l.outstanding_balance ?? 0) > 0))
 

--- a/src/routes/(onboarding)/finances/edit/tangible-assets/+page.svelte
+++ b/src/routes/(onboarding)/finances/edit/tangible-assets/+page.svelte
@@ -56,19 +56,11 @@
     }))
   }
 
-  let assets = $state<AssetUI[]>([])
-  let assetCounter = $state(0)
-  let hydrated = $state(false)
-
-  $effect(() => {
-    if (hydrated || appStore.loading) return
-    const stored = appStore.profile.tangible_assets
-    if (stored && stored.length > 0) {
-      assets = storedToUI(stored)
-      assetCounter = assets.length
-    }
-    hydrated = true
-  })
+  // The store is loaded before render (see +layout.ts), so the profile is
+  // already populated here — seed the form state directly.
+  const initialAssets = storedToUI(appStore.profile.tangible_assets ?? [])
+  let assets = $state<AssetUI[]>(initialAssets)
+  let assetCounter = $state(initialAssets.length)
 
   let canContinue = $derived(assets.some((a) => (a.value ?? 0) > 0))
 

--- a/src/routes/(onboarding)/profile/+page.svelte
+++ b/src/routes/(onboarding)/profile/+page.svelte
@@ -19,26 +19,14 @@
     getMonthOptions,
   } from '$lib/utils'
 
-  let name = $state('')
-  let birthYear = $state('')
-  let birthMonth = $state('')
-  let location = $state('')
-  let currency = $state('')
-  let hydrated = $state(false)
-
-  // Hydrate form state from the store exactly once, on first load.
-  $effect(() => {
-    if (hydrated || appStore.loading) return
-    const p = appStore.profile
-    name = p.name
-    if (p.location) location = p.location
-    if (p.currency) currency = p.currency
-    if (p.birthDate) {
-      birthYear = String(p.birthDate.getFullYear())
-      birthMonth = String(p.birthDate.getMonth())
-    }
-    hydrated = true
-  })
+  // The store is loaded before render (see +layout.ts), so the profile is
+  // already populated here — seed the form state directly.
+  const p = appStore.profile
+  let name = $state(p.name)
+  let birthYear = $state(p.birthDate ? String(p.birthDate.getFullYear()) : '')
+  let birthMonth = $state(p.birthDate ? String(p.birthDate.getMonth()) : '')
+  let location = $state(p.location ?? '')
+  let currency = $state(p.currency ?? '')
 
   const years = getBirthYearOptions().map((year) => ({ value: year, label: year }))
   const months = getMonthOptions()

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -15,7 +15,8 @@
   })
 
   onMount(() => {
-    appStore.load()
+    // Data is loaded synchronously in +layout.ts before render; here we only
+    // wire up cross-tab sync, which needs the browser `window`.
     cleanupSync = appStore.startSync()
   })
 

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,10 +1,17 @@
 // Import to initialize. Important :)
 import { waitLocale } from 'svelte-i18n'
 
+import { browser } from '$app/environment'
+
 import '$lib/locales'
+import { appStore } from '$lib/stores/app.svelte'
 
 import type { LayoutLoad } from './$types'
 
 export const load: LayoutLoad = async () => {
+  // Read localStorage synchronously here (before any component renders) so the
+  // store is populated when route components evaluate their $state initializers.
+  // This avoids the "store not loaded yet" race where defaults leak in.
+  if (browser) appStore.load()
   await waitLocale()
 }


### PR DESCRIPTION
Closes #81. Closes #98.

Stacked on #94. Contains two related changes.

## 1. Load the store before render (root-cause fix)

`appStore.load()` is a **synchronous** localStorage read, but it was called in the root layout's `onMount` — which runs *after* route components evaluate their `$state` initializers. So `appStore.profile` is still empty during a component's first render, and defaults leak in.

#94 fixed one symptom (add-plan details currency defaulting to EUR on reload/deep-link) with an `$effect` + `hydrated` flag. The **same workaround was copy-pasted across 7 onboarding pages**.

**Fix:** move the load into the root `+layout.ts` universal `load()`, which resolves *before* SvelteKit renders the component tree (it already awaits `waitLocale()` there for the same reason). Guarded with `browser` because adapter-static prerenders the `index.html` shell where `localStorage` doesn't exist. `onMount` keeps only `startSync()`.

With the root cause gone, the hydration workarounds are removed:
- #94's `$effect`/`hydrated` flag on the add-plan details step.
- The 7 onboarding edit pages (`profile`, `finances/edit`, and the expenses/income/investments/liabilities/tangible-assets lists) now seed their form `$state` directly from the (already-loaded) profile, dropping the effect + flag in each.

## 2. Remove per-plan currency entirely

While reviewing the currency default, we found per-plan currency was stored but **never actually supported**:

- **No FX/conversion** anywhere — the calculation engine never even reads `currency`. A different-currency plan computes on the same raw numbers, it doesn't convert them.
- **Display ignored it** — every formatter uses `profile.currencyOrDefault`, not the portfolio's currency.

So a divergent plan currency would silently *mislabel* numbers rather than convert them. Rather than keep a meaningless field, currency is removed end to end:

- **UI:** the currency selector is gone from the add-plan wizard (inflation becomes full-width); the unused `page.addPlan.details.currency` locale key is removed from `cs`/`en`.
- **Schema/model:** `currency` removed from `portfolioSchema` (and thus `PortfolioNested` / `PortfolioStore`), the portfolio store (`$state`, getter/setter, `toJSON`), the add-plan data step, and test fixtures.

**Existing data is safe:** `portfolioSchema` is a non-strict `z.object`, so a leftover `currency` key on old localStorage plans is silently stripped on parse (verified: a seeded legacy plan with `currency: 'EUR'` loads fine and is dropped from storage on the next save). Display is unchanged because formatting already used the profile currency.

## Verification

- **Load fix + onboarding hydration:** seeded a profile with name/birth date/location/currency/cash/`has_*` flags and an expense, then loaded each page — `profile` (name, year, month, country, currency), `finances/edit` (cash + checkbox cards), and `finances/edit/expenses` (the Rent row) all pre-fill correctly from the directly-seeded state. Deep-link to `/plan/add/details` populates the store before render; dashboard shows no welcome-screen flash.
- **Currency removal:** add-plan step shows no currency field (inflation full-width); completing the wizard creates a portfolio with **no** `currency` key. Seeded legacy data with a stray `currency` loads without error and is stripped on re-save.
- `pnpm check`, `pnpm check-locales`, `pnpm knip` pass; affected unit tests pass (116); changed files lint clean; no console errors.

## Follow-up (not here)

- If multi-currency becomes a real feature later, it needs per-plan amounts + an FX source + currency threaded through the engine and formatters — a fresh design, not a revived field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)