### PR TITLE
ci: add concurrency groups to check and deploy-prod workflows

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -8,6 +8,10 @@ on:
     branches:
       - '**'
 
+concurrency:
+  group: check-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
 permissions:
   contents: write
 


### PR DESCRIPTION
Adds concurrency control to the two workflows that were missing it:

- **deploy-prod**: `group: deploy-prod` with `cancel-in-progress: false`, so production deploys to `gh-pages` are serialized — two quick merges can no longer race and let an older build win or fail the push.
- **check**: `group: check-${{ github.ref }}` with `cancel-in-progress: true`, so a new push to a PR cancels the now-redundant in-flight run instead of queueing a duplicate.

The Dependabot npm ecosystem suggestion from the issue is intentionally omitted per the maintainer comment there.

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)