### PR TITLE
perf: cache Intl.NumberFormat instances in formatters

### DIFF
--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -7,6 +7,7 @@ import {
   formatCompactCurrency,
   formatCurrency,
   formatCurrencyCode,
+  formatNumber,
   getFormattingLocale,
   parseDateOnly,
 } from '$lib/utils'
@@ -191,7 +192,7 @@ function withAppStore() {
 
     formatNumber(value: number) {
       const loc = getFormattingLocale(profile.location, browserLocale)
-      return value.toLocaleString(loc ?? undefined, { maximumFractionDigits: 4 })
+      return formatNumber(value, loc)
     },
     formatCurrency(value: number) {
       const loc = getFormattingLocale(profile.location, browserLocale)

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from 'vitest'
 
 import {
   formatCompactCurrency,
+  formatCurrency,
+  formatCurrencyCode,
+  formatNumber,
   getFormattingLocale,
   parseDateOnly,
   toDateOnlyString,
@@ -25,6 +28,32 @@ describe('getFormattingLocale', () => {
 describe('formatCompactCurrency', () => {
   it('does not emit Hungarian compact format for an explicit locale (issue #41)', () => {
     expect(formatCompactCurrency(150200, 'EUR', 'en')).not.toContain('E EUR')
+  })
+})
+
+describe('cached formatters', () => {
+  it('returns stable results on repeated calls', () => {
+    expect(formatCurrency(1234567, 'USD', 'en-US')).toBe('$1,234,567')
+    expect(formatCurrency(1234567, 'USD', 'en-US')).toBe('$1,234,567')
+    expect(formatNumber(1234.5678, 'en-US')).toBe('1,234.5678')
+    expect(formatNumber(1234.5678, 'en-US')).toBe('1,234.5678')
+  })
+
+  it('does not mix up formatters with the same locale and currency but different options', () => {
+    expect(formatCurrency(1000, 'USD', 'en-US')).toBe('$1,000')
+    expect(formatCurrencyCode(1000, 'USD', 'en-US')).toBe('USD\u00a01,000')
+    expect(formatCompactCurrency(1500, 'USD', 'en-US')).toBe('$1.5K')
+    expect(formatCurrency(1000, 'USD', 'en-US')).toBe('$1,000')
+  })
+
+  it('distinguishes locales and currencies in the cache', () => {
+    expect(formatCurrency(1000, 'CZK', 'cs-CZ')).toBe('1\u00a0000\u00a0Kč')
+    expect(formatCurrency(1000, 'EUR', 'cs-CZ')).toBe('1\u00a0000\u00a0€')
+    expect(formatCurrency(1000, 'CZK', 'en-US')).toBe('CZK\u00a01,000')
+  })
+
+  it('falls back for unsupported currency codes', () => {
+    expect(formatCurrency(1000, 'NOTACURRENCY', 'en-US')).toBe('1,000 NOTACURRENCY')
   })
 })
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -92,9 +92,34 @@ export function notImplemented() {
   alert('Not implemented yet')
 }
 
+/**
+ * Cache of Intl.NumberFormat instances keyed by locale + options.
+ * Constructing a formatter is expensive and these run inside hot $derived
+ * chains; the key includes locale and currency, so the cache self-invalidates
+ * when the profile or browser locale changes.
+ */
+const numberFormatCache = new Map<string, Intl.NumberFormat>()
+
+function getNumberFormat(
+  locale: string | undefined,
+  options: Intl.NumberFormatOptions,
+): Intl.NumberFormat {
+  const key = `${locale}|${JSON.stringify(options)}`
+  let formatter = numberFormatCache.get(key)
+  if (!formatter) {
+    formatter = new Intl.NumberFormat(locale ?? undefined, options)
+    numberFormatCache.set(key, formatter)
+  }
+  return formatter
+}
+
+export function formatNumber(value: number, locale?: string): string {
+  return getNumberFormat(locale, { maximumFractionDigits: 4 }).format(value)
+}
+
 export function formatCurrency(value: number, currency: string, locale?: string): string {
   try {
-    return new Intl.NumberFormat(locale ?? undefined, {
+    return getNumberFormat(locale, {
       style: 'currency',
       currency,
       maximumFractionDigits: 0,
@@ -107,7 +132,7 @@ export function formatCurrency(value: number, currency: string, locale?: string)
 
 export function formatCurrencyCode(value: number, currency: string, locale?: string): string {
   try {
-    return new Intl.NumberFormat(locale ?? undefined, {
+    return getNumberFormat(locale, {
       style: 'currency',
       currency,
       currencyDisplay: 'code',
@@ -121,7 +146,7 @@ export function formatCurrencyCode(value: number, currency: string, locale?: str
 
 export function formatCompactCurrency(value: number, currency: string, locale?: string): string {
   try {
-    return new Intl.NumberFormat(locale ?? undefined, {
+    return getNumberFormat(locale, {
       style: 'currency',
       currency,
       notation: 'compact',


### PR DESCRIPTION
## Summary

- Add a module-level `Map<string, Intl.NumberFormat>` cache in `src/lib/utils.ts`, keyed by locale + all formatter options, so `formatCurrency`, `formatCurrencyCode`, and `formatCompactCurrency` reuse formatter instances instead of constructing one per call.
- Since the cache key includes the locale and currency, it self-invalidates when `profile.location`, the profile currency, or `browserLocale` changes — no explicit invalidation needed.
- Move `appStore.formatNumber` onto the same cache via a new low-level `formatNumber` util (previously `value.toLocaleString(...)`, which also constructs a formatter per call).
- Outputs are byte-for-byte identical; the pass-formatter-functions convention (`appStore.formatNumber` etc. as props) is unchanged.
- Add unit tests covering repeated calls, option/locale/currency cache-key separation, and the unsupported-currency fallback.

These formatters run inside `$derived` chains keyed to high-frequency state on the plan page (year slider, search keystrokes, chart hover), causing ~10-30 constructions per interaction.

Closes #142

## Testing

- `pnpm test:unit run` — 330 tests pass
- `pnpm check:all` — format, lint, check, knip, check-locales all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)