### PR TITLE
refactor: dedupe timingComplete and filterById plan helpers

### DIFF
--- a/src/lib/plan-projection.ts
+++ b/src/lib/plan-projection.ts
@@ -338,7 +338,7 @@ function transferAmountForYear(
     .mul(fraction)
 }
 
-function filterById<T extends { id: string }>(
+export function filterById<T extends { id: string }>(
   items: T[] | undefined,
   includedIds: string[] | undefined,
 ): T[] {

--- a/src/lib/schemas.test.ts
+++ b/src/lib/schemas.test.ts
@@ -1,0 +1,98 @@
+import { addMessages, init } from 'svelte-i18n'
+
+import { describe, expect, it } from 'vitest'
+
+import en from './locales/en.json'
+import { incomeSchema, timingComplete } from './schemas'
+import type { CashFlowEnd, CashFlowStart } from './schemas'
+
+// The temporal refinement resolves its error messages through svelte-i18n at
+// parse time, so the locale must be initialized before any failing parse.
+addMessages('en', en)
+init({ fallbackLocale: 'en', initialLocale: 'en' })
+
+interface TimingVariant<M> {
+  mode: M
+  year?: number
+  month?: number
+  age?: number
+}
+
+const startVariants: TimingVariant<CashFlowStart>[] = [
+  { mode: 'immediately' },
+  { mode: 'now' },
+  { mode: 'at_specific_date', year: 2030, month: 6 },
+  { mode: 'at_specific_date', year: 2030 },
+  { mode: 'at_specific_date', month: 6 },
+  { mode: 'at_specific_date' },
+  { mode: 'when_age_is', age: 40 },
+  { mode: 'when_age_is' },
+]
+
+const endVariants: TimingVariant<CashFlowEnd>[] = [
+  { mode: 'never' },
+  { mode: 'at_specific_date', year: 2040, month: 12 },
+  { mode: 'at_specific_date', year: 2040 },
+  { mode: 'at_specific_date', month: 12 },
+  { mode: 'at_specific_date' },
+  { mode: 'when_age_is', age: 60 },
+  { mode: 'when_age_is' },
+]
+
+function label(variant: TimingVariant<CashFlowStart | CashFlowEnd>): string {
+  const fields = [
+    variant.year !== undefined ? 'year' : undefined,
+    variant.month !== undefined ? 'month' : undefined,
+    variant.age !== undefined ? 'age' : undefined,
+  ].filter((f) => f !== undefined)
+  return `${variant.mode}(${fields.join('+') || 'no fields'})`
+}
+
+describe('timingComplete', () => {
+  it('requires year and month for at_specific_date', () => {
+    expect(timingComplete('at_specific_date', 2030, 6, undefined)).toBe(true)
+    expect(timingComplete('at_specific_date', 2030, undefined, undefined)).toBe(false)
+    expect(timingComplete('at_specific_date', undefined, 6, undefined)).toBe(false)
+    expect(timingComplete('at_specific_date', undefined, undefined, undefined)).toBe(false)
+  })
+
+  it('requires age for when_age_is', () => {
+    expect(timingComplete('when_age_is', undefined, undefined, 40)).toBe(true)
+    expect(timingComplete('when_age_is', undefined, undefined, undefined)).toBe(false)
+  })
+
+  it('is always complete for modes without extra fields', () => {
+    expect(timingComplete('immediately', undefined, undefined, undefined)).toBe(true)
+    expect(timingComplete('now', undefined, undefined, undefined)).toBe(true)
+    expect(timingComplete('never', undefined, undefined, undefined)).toBe(true)
+  })
+
+  describe('matches the cashFlowTemporalRefinement accept/reject behavior', () => {
+    for (const start of startVariants) {
+      for (const end of endVariants) {
+        it(`start=${label(start)} end=${label(end)}`, () => {
+          const income = {
+            id: 'income-1',
+            name: 'Salary',
+            amount: 1000,
+            frequency: 'monthly' as const,
+            withhold_taxes: false,
+            change_over_time: 'none' as const,
+            start: start.mode,
+            start_year: start.year,
+            start_month: start.month,
+            start_age: start.age,
+            end: end.mode,
+            end_year: end.year,
+            end_month: end.month,
+            end_age: end.age,
+          }
+          const expected =
+            timingComplete(start.mode, start.year, start.month, start.age) &&
+            timingComplete(end.mode, end.year, end.month, end.age)
+          expect(incomeSchema.safeParse(income).success).toBe(expected)
+        })
+      }
+    }
+  })
+})

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -97,6 +97,21 @@ const cashFlowTemporalRefinement = (
   }
 }
 
+// A timing edge ('start' or 'end') is complete only once the mode-specific
+// field is filled — otherwise the projection would silently fall back to the
+// plan's first year. Mirrors cashFlowTemporalRefinement above; forms use it
+// to gate saving before the data ever reaches the schema.
+export function timingComplete(
+  mode: CashFlowStart | CashFlowEnd,
+  year: number | undefined,
+  month: number | undefined,
+  age: number | undefined,
+): boolean {
+  if (mode === 'at_specific_date') return year !== undefined && month !== undefined
+  if (mode === 'when_age_is') return age !== undefined
+  return true
+}
+
 export const incomeSchema = z
   .object({
     id: z.string(),

--- a/src/routes/(app)/plan/[id]/CashFlowEditDialog.svelte
+++ b/src/routes/(app)/plan/[id]/CashFlowEditDialog.svelte
@@ -14,6 +14,7 @@
   import { Input } from '$lib/components/ui/input'
   import { Label } from '$lib/components/ui/label'
   import { Separator } from '$lib/components/ui/separator'
+  import { timingComplete } from '$lib/schemas'
   import type {
     CashFlowEnd,
     CashFlowStart,
@@ -202,20 +203,6 @@
           ? (f.change_percentage ?? 0)
           : undefined,
     }
-  }
-
-  // A timing edge ('start' or 'end') is complete only once the mode-specific
-  // field is filled — otherwise the projection would silently fall back to the
-  // plan's first year (see schemas.ts cashFlowTemporalRefinement).
-  function timingComplete(
-    mode: CashFlowStart | CashFlowEnd,
-    year: number | undefined,
-    month: number | undefined,
-    age: number | undefined,
-  ): boolean {
-    if (mode === 'at_specific_date') return year !== undefined && month !== undefined
-    if (mode === 'when_age_is') return age !== undefined
-    return true
   }
 
   const canSave = $derived(

--- a/src/routes/(app)/plan/[id]/TransferEditDialog.svelte
+++ b/src/routes/(app)/plan/[id]/TransferEditDialog.svelte
@@ -14,6 +14,8 @@
   import { Label } from '$lib/components/ui/label'
   import { Switch } from '$lib/components/ui/switch'
   import * as Tooltip from '$lib/components/ui/tooltip'
+  import { filterById } from '$lib/plan-projection'
+  import { timingComplete } from '$lib/schemas'
   import type {
     CashFlowEnd,
     CashFlowStart,
@@ -67,27 +69,16 @@
   let months = $derived(getMonthOptions($locale ?? undefined))
   let currencyLabel = $derived(appStore.profile.currencyOrDefault)
 
-  // Build the From/To asset list from the profile, filtered by plan inclusion
-  // (mirrors `filterById` in plan-projection.ts so the dropdowns and the
-  // projection see the same asset set).
-  function included<T extends { id: string }>(
-    items: T[] | undefined,
-    includedIds: string[] | undefined,
-  ): T[] {
-    if (!items) return []
-    if (!includedIds) return items
-    const set = new Set(includedIds)
-    return items.filter((i) => set.has(i.id))
-  }
-
   // Transfers can only move between cash and investments. Tangible assets and
   // liabilities are intentionally excluded — selling/buying a house is more
   // naturally modelled as a one-off expense/income.
+  // The list is filtered by plan inclusion via the same filterById the
+  // projection uses, so the dropdowns and the projection see the same assets.
   const assetOptions = $derived<{ id: string; name: string }[]>([
     ...(plan.include_cash !== false && appStore.profile.cash_amount
       ? [{ id: 'cash', name: $_('page.plan.cashItem') }]
       : []),
-    ...included(appStore.profile.investments, plan.included_investment_ids).map((inv) => ({
+    ...filterById(appStore.profile.investments, plan.included_investment_ids).map((inv) => ({
       id: inv.id,
       name: inv.name,
     })),
@@ -299,20 +290,6 @@
     const next = (plan.transfers ?? []).filter((t) => t.id !== form.id)
     plan.update({ transfers: next })
     close()
-  }
-
-  // A timing edge ('start' or 'end') is complete only once the mode-specific
-  // field is filled — otherwise the projection would silently fall back to the
-  // plan's first year (see schemas.ts cashFlowTemporalRefinement).
-  function timingComplete(
-    mode: CashFlowStart | CashFlowEnd,
-    year: number | undefined,
-    month: number | undefined,
-    age: number | undefined,
-  ): boolean {
-    if (mode === 'at_specific_date') return year !== undefined && month !== undefined
-    if (mode === 'when_age_is') return age !== undefined
-    return true
   }
 
   const canSave = $derived(


### PR DESCRIPTION
Removes two verbatim helper copies that could silently desync:

- `timingComplete()` now lives in `src/lib/schemas.ts` next to `cashFlowTemporalRefinement` (the Zod refinement it mirrors) and is imported by both `CashFlowEditDialog` and `TransferEditDialog` instead of being copy-pasted in each.
- `filterById()` is now exported from `src/lib/plan-projection.ts` and used by `TransferEditDialog` in place of its local `included()` copy, so the transfer From/To dropdowns and the projection always agree on the asset set.

All three call sites were behaviorally identical (the only difference was a loop variable name), so no behavior changes.

Adds `src/lib/schemas.test.ts` asserting that `timingComplete` matches the refinement's accept/reject behavior: for the full matrix of start/end timing variants, `incomeSchema.safeParse(x).success === timingComplete(start edge) && timingComplete(end edge)`.

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)