### PR TITLE
fix: localize notImplemented alert and default plan names

### DIFF
--- a/src/lib/locales/cs.json
+++ b/src/lib/locales/cs.json
@@ -22,7 +22,8 @@
         "endWhenAgeIs": "Když vám bude",
         "endAtDate": "K určitému datu...",
         "yearsOld": "Let",
-        "inflation": "Inflace"
+        "inflation": "Inflace",
+        "defaultName": "Plán {index}"
       },
       "data": {
         "title": "Finanční data",
@@ -350,7 +351,8 @@
       "france": "Francie",
       "other": "Jiné"
     },
-    "currency": "Měna"
+    "currency": "Měna",
+    "notImplemented": "Zatím není implementováno"
   },
   "theme": {
     "light": "Světlý",

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -22,7 +22,8 @@
         "endWhenAgeIs": "When your age is",
         "endAtDate": "At specific date...",
         "yearsOld": "Years old",
-        "inflation": "Inflation"
+        "inflation": "Inflation",
+        "defaultName": "Plan {index}"
       },
       "data": {
         "title": "Financial data",
@@ -350,7 +351,8 @@
       "france": "France",
       "other": "Other"
     },
-    "currency": "Currency"
+    "currency": "Currency",
+    "notImplemented": "Not implemented yet"
   },
   "theme": {
     "light": "Light",

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,6 @@
+import { _ } from 'svelte-i18n'
+import { get } from 'svelte/store'
+
 import { type ClassValue, clsx } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 
@@ -89,7 +92,7 @@ export function toDateOnlyString(date: Date): string {
 }
 
 export function notImplemented() {
-  alert('Not implemented yet')
+  alert(get(_)('common.notImplemented'))
 }
 
 export function formatCurrency(value: number, currency: string, locale?: string): string {

--- a/src/routes/(add-plan)/plan/add/details/+page.svelte
+++ b/src/routes/(add-plan)/plan/add/details/+page.svelte
@@ -21,7 +21,7 @@
   // Generate a default plan name based on existing portfolios
   function getDefaultPlanName(): string {
     const existingCount = appStore.portfolios.length
-    return `Plan ${existingCount + 1}`
+    return $_('page.addPlan.details.defaultName', { values: { index: existingCount + 1 } })
   }
 
   let name = $state(getDefaultPlanName())


### PR DESCRIPTION
## Summary

Two user-facing strings bypassed localization:

- `notImplemented()` in `src/lib/utils.ts` showed a hardcoded English alert ("Not implemented yet") on the eight production controls wired to it. It now resolves the new `common.notImplemented` key via `get(_)` from svelte-i18n, following the existing pattern in `src/lib/schemas.ts`.
- New plans were named with a hardcoded `Plan ${n}`. `getDefaultPlanName()` in the add-plan details page now uses the new `page.addPlan.details.defaultName` key ("Plan {index}" / "Plán {index}"), matching the `defaultName` pattern used by every other entity.

Both keys were added to `cs.json` and `en.json` with identical structure and parameter names.

## Testing

- `pnpm check:all` passes (format, lint, check, knip, check-locales — no missing/unused keys)
- `pnpm test:unit run` — 326 tests pass
- Verified in the browser: default plan name renders "Plan 1" from the localized key through the add-plan flow, and the Compare plan button's alert text resolves through i18n

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)