### PR TITLE
refactor: centralize storage keys in a shared module

### DIFF
--- a/src/lib/components/theme-switcher.svelte
+++ b/src/lib/components/theme-switcher.svelte
@@ -5,6 +5,7 @@
 
   import { Button } from '$lib/components/ui/button'
   import * as DropdownMenu from '$lib/components/ui/dropdown-menu'
+  import storageKeys from '$lib/storage-keys'
 
   type Theme = 'light' | 'dark' | 'system'
 
@@ -27,12 +28,12 @@
 
   function setTheme(t: Theme) {
     theme = t
-    localStorage.setItem('theme', t)
+    localStorage.setItem(storageKeys.THEME, t)
     applyTheme(t)
   }
 
   $effect(() => {
-    const stored = localStorage.getItem('theme') as Theme | undefined
+    const stored = localStorage.getItem(storageKeys.THEME) as Theme | undefined
     if (stored === 'light' || stored === 'dark' || stored === 'system') {
       theme = stored
     } else {

--- a/src/lib/locales/index.ts
+++ b/src/lib/locales/index.ts
@@ -2,8 +2,9 @@ import { init, register } from 'svelte-i18n'
 
 import { browser } from '$app/environment'
 
+import storageKeys from '$lib/storage-keys'
+
 export const defaultLocale = 'en'
-export const LOCALE_STORAGE_KEY = 'locale'
 const supportedLocales = ['en', 'cs']
 
 register('en', () => import('$lib/locales/en.json'))
@@ -12,7 +13,7 @@ register('cs', () => import('$lib/locales/cs.json'))
 function resolveLocale(): string {
   if (!browser) return defaultLocale
 
-  const stored = localStorage.getItem(LOCALE_STORAGE_KEY)
+  const stored = localStorage.getItem(storageKeys.LOCALE)
   if (stored && supportedLocales.includes(stored)) return stored
 
   for (const language of navigator.languages) {

--- a/src/lib/storage-keys.ts
+++ b/src/lib/storage-keys.ts
@@ -1,0 +1,22 @@
+/**
+ * Central registry of localStorage/sessionStorage keys used across the app.
+ *
+ * Always add new storage keys here instead of hard-coding string literals
+ * at the call site. This keeps keys in one place so they stay consistent
+ * across readers and writers (e.g. the dev page reset clearing the same
+ * key the app store persists to) and makes them easy to change or mock.
+ *
+ * Usage:
+ *   import storageKeys from '$lib/storage-keys'
+ *   localStorage.getItem(storageKeys.DATA)
+ */
+export default {
+  /** localStorage — persisted app data (profile, portfolios, plans). */
+  DATA: 'kalkul-data',
+  /** sessionStorage — in-progress add-plan wizard draft. */
+  PLAN_DRAFT: 'kalkul-plan-draft',
+  /** localStorage — selected color theme ('light' | 'dark' | 'system'). */
+  THEME: 'theme',
+  /** localStorage — selected UI language override. */
+  LOCALE: 'locale',
+} as const

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -1,6 +1,7 @@
 import { SvelteSet } from 'svelte/reactivity'
 
 import { type StoredData, profileSchema, storedDataSchema } from '$lib/schemas'
+import storageKeys from '$lib/storage-keys'
 import type { Portfolio, PortfolioNested, Profile } from '$lib/types'
 import {
   DEFAULT_CURRENCY,
@@ -14,8 +15,6 @@ import {
 import type { PortfolioStore } from './portfolio.svelte'
 import { withPortfolioStore } from './portfolio.svelte'
 import { storageErrorStore } from './storage-error.svelte'
-
-const STORAGE_KEY = 'kalkul-data'
 
 export type ProfileStore = Profile & {
   readonly birthDate: Date | undefined
@@ -91,7 +90,7 @@ const DEFAULT_PROFILE: Profile = {
 
 function loadData(): StoredData {
   try {
-    const raw = localStorage.getItem(STORAGE_KEY)
+    const raw = localStorage.getItem(storageKeys.DATA)
     if (raw) {
       return storedDataSchema.parse(JSON.parse(raw))
     }
@@ -117,7 +116,7 @@ function withAppStore() {
       portfolios: portfolios.map((p) => p.toJSON()),
     }
     try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(stored))
+      localStorage.setItem(storageKeys.DATA, JSON.stringify(stored))
       lastUpdated = now
       storageErrorStore.clear()
     } catch (e) {
@@ -243,7 +242,7 @@ function withAppStore() {
 
     startSync(): () => void {
       function onStorage(event: StorageEvent): void {
-        if (event.key !== STORAGE_KEY || !event.newValue) return
+        if (event.key !== storageKeys.DATA || !event.newValue) return
 
         try {
           const data = storedDataSchema.parse(JSON.parse(event.newValue))

--- a/src/routes/(add-plan)/plan/add/data/+page.svelte
+++ b/src/routes/(add-plan)/plan/add/data/+page.svelte
@@ -13,6 +13,7 @@
   import { Label } from '$lib/components/ui/label'
   import { Separator } from '$lib/components/ui/separator'
   import routes from '$lib/routes'
+  import storageKeys from '$lib/storage-keys'
   import { appStore } from '$lib/stores/app.svelte'
 
   // State for included items - all checked by default
@@ -102,7 +103,7 @@
 
   function handleCreatePlan() {
     // Load plan details from sessionStorage
-    const draftStr = sessionStorage.getItem('kalkul-plan-draft')
+    const draftStr = sessionStorage.getItem(storageKeys.PLAN_DRAFT)
     if (!draftStr) {
       // Fallback if no draft
       goto(resolve(routes.HOME))
@@ -144,7 +145,7 @@
     })
 
     // Clean up
-    sessionStorage.removeItem('kalkul-plan-draft')
+    sessionStorage.removeItem(storageKeys.PLAN_DRAFT)
 
     // Navigate to the new plan page
     goto(resolve(`${routes.PLAN_VIEW}/${portfolioId}`))

--- a/src/routes/(add-plan)/plan/add/details/+page.svelte
+++ b/src/routes/(add-plan)/plan/add/details/+page.svelte
@@ -15,6 +15,7 @@
   import { Textarea } from '$lib/components/ui/textarea'
   import routes from '$lib/routes'
   import type { PlanEndType, PlanStartType } from '$lib/schemas'
+  import storageKeys from '$lib/storage-keys'
   import { appStore } from '$lib/stores/app.svelte'
   import { getMonthOptions, getYearOptions } from '$lib/utils'
 
@@ -96,7 +97,7 @@
       end_date: getEndDate(),
       inflation_rate: (inflation ?? 2) / 100,
     }
-    sessionStorage.setItem('kalkul-plan-draft', JSON.stringify(planDetails))
+    sessionStorage.setItem(storageKeys.PLAN_DRAFT, JSON.stringify(planDetails))
     // URL is already resolved by getNextAddPlanStepUrl
     // eslint-disable-next-line svelte/no-navigation-without-resolve
     goto(getNextAddPlanStepUrl(routes.PLAN_ADD_DETAILS, appStore.profile))

--- a/src/routes/dev/+page.svelte
+++ b/src/routes/dev/+page.svelte
@@ -6,6 +6,7 @@
   import { CATEGORY_COLORS } from '$lib/chart-colors'
   import { Button } from '$lib/components/ui/button'
   import routes from '$lib/routes'
+  import storageKeys from '$lib/storage-keys'
   import { appStore } from '$lib/stores/app.svelte'
 
   const colorCategories = [
@@ -416,7 +417,7 @@
   function loadPreset(preset: (typeof presets)[number]) {
     if (preset.data.profile.name === '') {
       appStore.reset()
-      localStorage.removeItem('kalkul-data')
+      localStorage.removeItem(storageKeys.DATA)
       appStore.loading = false
     } else {
       appStore.importBackup(JSON.stringify(preset.data))


### PR DESCRIPTION
Adds `src/lib/storage-keys.ts` as the single registry of localStorage/sessionStorage keys, mirroring the `external-links.ts` pattern, and replaces every hard-coded key literal with it:

- `kalkul-data` — app store (`src/lib/stores/app.svelte.ts`, private `STORAGE_KEY` removed) and the dev page reset, which previously re-hardcoded the literal
- `kalkul-plan-draft` — both add-plan wizard steps (`plan/add/details` and `plan/add/data`)
- `theme` — theme switcher (two bare literals)
- `locale` — `src/lib/locales/index.ts`; `LOCALE_STORAGE_KEY` was migrated into the registry and its export removed, since it had no importers outside its own file and `storage-keys.ts` has no imports, so no circular-import risk

No behavior change: all key values are identical, only their definition site moved.

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)