### PR TITLE
refactor: centralize frequency/status select options

### DIFF
--- a/src/lib/components/cash-flow-item-card.svelte
+++ b/src/lib/components/cash-flow-item-card.svelte
@@ -11,6 +11,7 @@
   import { Separator } from '$lib/components/ui/separator'
   import { Switch } from '$lib/components/ui/switch'
   import type { CashFlowEnd, CashFlowStart, ChangeOverTime, Frequency } from '$lib/schemas'
+  import { getFrequencyItems } from '$lib/select-options'
 
   interface CashFlowItem {
     id: string
@@ -70,11 +71,7 @@
     extraAdvancedContent,
   }: Props = $props()
 
-  let frequencyItems = $derived([
-    { value: 'monthly', label: $_('page.setup.common.monthly') },
-    { value: 'yearly', label: $_('page.setup.common.yearly') },
-    { value: 'weekly', label: $_('page.setup.common.weekly') },
-  ])
+  let frequencyItems = $derived(getFrequencyItems($_))
 
   let sign = $derived(sentiment === 'positive' ? '+' : '-')
   let collapsedValueClass = $derived(sentiment === 'positive' ? 'text-success' : 'text-destructive')

--- a/src/lib/components/liabilities-editor.svelte
+++ b/src/lib/components/liabilities-editor.svelte
@@ -12,6 +12,7 @@
   import { Label } from '$lib/components/ui/label'
   import { Switch } from '$lib/components/ui/switch'
   import type { Frequency, ProfileLiability } from '$lib/schemas'
+  import { getFrequencyItems } from '$lib/select-options'
   import { appStore } from '$lib/stores/app.svelte'
   import { notImplemented } from '$lib/utils'
 
@@ -59,11 +60,7 @@
 
   let currencyLabel = $derived(appStore.profile.currencyOrDefault)
 
-  let frequencyItems = $derived([
-    { value: 'monthly', label: $_('page.setup.common.monthly') },
-    { value: 'yearly', label: $_('page.setup.common.yearly') },
-    { value: 'weekly', label: $_('page.setup.common.weekly') },
-  ])
+  let frequencyItems = $derived(getFrequencyItems($_))
 
   function addLiability() {
     liabilityCounter++

--- a/src/lib/components/tangible-assets-editor.svelte
+++ b/src/lib/components/tangible-assets-editor.svelte
@@ -12,6 +12,7 @@
   import { Label } from '$lib/components/ui/label'
   import { Switch } from '$lib/components/ui/switch'
   import type { Frequency, ProfileTangibleAsset, TangibleAssetStatus } from '$lib/schemas'
+  import { getFrequencyItems, getTangibleAssetStatusItems } from '$lib/select-options'
   import { appStore } from '$lib/stores/app.svelte'
   import { notImplemented } from '$lib/utils'
 
@@ -70,16 +71,9 @@
 
   let currencyLabel = $derived(appStore.profile.currencyOrDefault)
 
-  let statusItems = $derived([
-    { value: 'fully_owned', label: $_('page.setup.tangibleAssets.fullyOwned') },
-    { value: 'financed', label: $_('page.setup.tangibleAssets.financed') },
-  ])
+  let statusItems = $derived(getTangibleAssetStatusItems($_))
 
-  let frequencyItems = $derived([
-    { value: 'monthly', label: $_('page.setup.common.monthly') },
-    { value: 'yearly', label: $_('page.setup.common.yearly') },
-    { value: 'weekly', label: $_('page.setup.common.weekly') },
-  ])
+  let frequencyItems = $derived(getFrequencyItems($_))
 
   function addAsset() {
     assetCounter++

--- a/src/lib/select-options.ts
+++ b/src/lib/select-options.ts
@@ -1,0 +1,32 @@
+import type { SelectFieldItem } from '$lib/components/select-field.svelte'
+import {
+  type Frequency,
+  type TangibleAssetStatus,
+  frequencySchema,
+  tangibleAssetStatusSchema,
+} from '$lib/schemas'
+
+// Translator function compatible with svelte-i18n's `$_`. Call sites pass `$_`
+// and wrap the helper in `$derived` so labels stay reactive to language switches.
+type Translator = (id: string) => string
+
+// Options are derived from the Zod enums so a newly added enum member fails the
+// typecheck here (via the `satisfies Record<...>`) instead of silently missing
+// from dropdowns.
+
+export function getFrequencyItems($_: Translator): SelectFieldItem[] {
+  const labels = {
+    monthly: $_('page.setup.common.monthly'),
+    yearly: $_('page.setup.common.yearly'),
+    weekly: $_('page.setup.common.weekly'),
+  } satisfies Record<Frequency, string>
+  return frequencySchema.options.map((value) => ({ value, label: labels[value] }))
+}
+
+export function getTangibleAssetStatusItems($_: Translator): SelectFieldItem[] {
+  const labels = {
+    fully_owned: $_('page.setup.tangibleAssets.fullyOwned'),
+    financed: $_('page.setup.tangibleAssets.financed'),
+  } satisfies Record<TangibleAssetStatus, string>
+  return tangibleAssetStatusSchema.options.map((value) => ({ value, label: labels[value] }))
+}

--- a/src/routes/(app)/plan/[id]/AssetEditDialog.svelte
+++ b/src/routes/(app)/plan/[id]/AssetEditDialog.svelte
@@ -32,6 +32,7 @@
     ProfileTangibleAsset,
     TangibleAssetStatus,
   } from '$lib/schemas'
+  import { getFrequencyItems, getTangibleAssetStatusItems } from '$lib/select-options'
   import { appStore } from '$lib/stores/app.svelte'
   import type { PortfolioStore } from '$lib/stores/portfolio.svelte'
 
@@ -204,16 +205,9 @@
     { value: 'fixed', label: $_('page.plan.exitFeeFixed') },
   ])
 
-  let tangibleAssetStatusItems = $derived([
-    { value: 'fully_owned', label: $_('page.setup.tangibleAssets.fullyOwned') },
-    { value: 'financed', label: $_('page.setup.tangibleAssets.financed') },
-  ])
+  let tangibleAssetStatusItems = $derived(getTangibleAssetStatusItems($_))
 
-  let frequencyItems = $derived([
-    { value: 'monthly', label: $_('page.setup.common.monthly') },
-    { value: 'yearly', label: $_('page.setup.common.yearly') },
-    { value: 'weekly', label: $_('page.setup.common.weekly') },
-  ])
+  let frequencyItems = $derived(getFrequencyItems($_))
 
   let interestTypeItems = $derived([
     { value: 'compound', label: $_('page.plan.interestCompound') },

--- a/src/routes/(app)/plan/[id]/CashFlowEditDialog.svelte
+++ b/src/routes/(app)/plan/[id]/CashFlowEditDialog.svelte
@@ -22,6 +22,7 @@
     Frequency,
     Income,
   } from '$lib/schemas'
+  import { getFrequencyItems } from '$lib/select-options'
   import { appStore } from '$lib/stores/app.svelte'
   import type { PortfolioStore } from '$lib/stores/portfolio.svelte'
   import { getMonthOptions, getYearOptions } from '$lib/utils'
@@ -62,11 +63,7 @@
   let months = $derived(getMonthOptions($locale ?? undefined))
   let currencyLabel = $derived(appStore.profile.currencyOrDefault)
 
-  let frequencyItems = $derived([
-    { value: 'monthly', label: $_('page.setup.common.monthly') },
-    { value: 'yearly', label: $_('page.setup.common.yearly') },
-    { value: 'weekly', label: $_('page.setup.common.weekly') },
-  ])
+  let frequencyItems = $derived(getFrequencyItems($_))
 
   function blankForm(): FormState {
     const counter =

--- a/src/routes/(app)/plan/[id]/TransferEditDialog.svelte
+++ b/src/routes/(app)/plan/[id]/TransferEditDialog.svelte
@@ -22,6 +22,7 @@
     Transfer,
     TransferSchedule,
   } from '$lib/schemas'
+  import { getFrequencyItems } from '$lib/select-options'
   import { appStore } from '$lib/stores/app.svelte'
   import type { PortfolioStore } from '$lib/stores/portfolio.svelte'
   import { getMonthOptions, getYearOptions } from '$lib/utils'
@@ -198,11 +199,7 @@
     { value: 'one_time', label: $_('page.plan.scheduleOneTime') },
     { value: 'recurring', label: $_('page.plan.scheduleRecurring') },
   ])
-  let frequencyItems = $derived([
-    { value: 'monthly', label: $_('page.setup.common.monthly') },
-    { value: 'yearly', label: $_('page.setup.common.yearly') },
-    { value: 'weekly', label: $_('page.setup.common.weekly') },
-  ])
+  let frequencyItems = $derived(getFrequencyItems($_))
   let yearItems = $derived(years.map((y) => ({ value: y, label: y })))
 
   function projectTransfer(f: FormState): Transfer {


### PR DESCRIPTION
The identical monthly/yearly/weekly options array was declared in six components, and the tangible-asset status array in two. This moves both to a shared `src/lib/select-options.ts` with `getFrequencyItems($_)` and `getTangibleAssetStatusItems($_)`.

- Values are derived from the Zod enums (`frequencySchema.options`, `tangibleAssetStatusSchema.options`); a `satisfies Record<Frequency, string>` on the label map makes a newly added enum member fail the typecheck instead of silently missing from dropdowns. Enum order already matches today's display order, so rendered output is unchanged (verified in the running app: both dropdowns render identical options/order/values).
- The translator (`$_`) is passed in by call sites and the helper call is wrapped in `$derived`, so labels stay reactive to language switches.
- All eight duplicated arrays were confirmed identical (same values, labels, order) before consolidation — no behavior differences to preserve.

Note: this PR is based on `main`. Open PR #151 also touches `CashFlowEditDialog.svelte`/`TransferEditDialog.svelte`, and in-flight work renames those files — depending on merge order this may need a trivial rebase.

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)