### PR TITLE
fix(a11y): keep dialog title mounted while renaming edit dialogs

### DIFF
--- a/src/lib/locales/cs.json
+++ b/src/lib/locales/cs.json
@@ -76,6 +76,7 @@
       "cancel": "Zrušit",
       "continue": "Pokračovat",
       "renameItem": "Přejmenovat",
+      "itemNameLabel": "Název položky",
       "duplicateItem": "Duplikovat",
       "deleteItem": "Smazat",
       "closeDialog": "Zavřít",

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -76,6 +76,7 @@
       "cancel": "Cancel",
       "continue": "Continue",
       "renameItem": "Rename",
+      "itemNameLabel": "Item name",
       "duplicateItem": "Duplicate",
       "deleteItem": "Delete",
       "closeDialog": "Close",

--- a/src/routes/(app)/plan/[id]/AssetEditDialog.svelte
+++ b/src/routes/(app)/plan/[id]/AssetEditDialog.svelte
@@ -437,6 +437,12 @@
 <Dialog.Root bind:open {onOpenChange}>
   <Dialog.Content showCloseButton={false} class="gap-0 p-0 sm:max-w-xl">
     <Dialog.Header class="flex flex-row items-center gap-1 border-b p-4 pe-3">
+      <!-- Dialog.Title stays mounted at all times so the dialog always has an
+      accessible name. While renaming it is visually hidden (but still exposed
+      to assistive tech) and the Input becomes the visible control. -->
+      <Dialog.Title class={editingName ? 'sr-only' : 'flex-1 truncate text-lg font-semibold'}>
+        {form.name}
+      </Dialog.Title>
       {#if editingName}
         <Input
           bind:ref={nameInputRef}
@@ -446,10 +452,9 @@
           onkeydown={(e) => {
             if (!isNew && (e.key === 'Enter' || e.key === 'Escape')) stopRenaming()
           }}
+          aria-label={$_('page.plan.itemNameLabel')}
           class="flex-1 text-lg font-semibold"
         />
-      {:else}
-        <Dialog.Title class="flex-1 truncate text-lg font-semibold">{form.name}</Dialog.Title>
       {/if}
 
       {#if !isNew}

--- a/src/routes/(app)/plan/[id]/CashFlowEditDialog.svelte
+++ b/src/routes/(app)/plan/[id]/CashFlowEditDialog.svelte
@@ -333,6 +333,12 @@
 <Dialog.Root bind:open {onOpenChange}>
   <Dialog.Content showCloseButton={false} class="gap-0 p-0 sm:max-w-xl">
     <Dialog.Header class="flex flex-row items-center gap-1 border-b p-4 pe-3">
+      <!-- Dialog.Title stays mounted at all times so the dialog always has an
+      accessible name. While renaming it is visually hidden (but still exposed
+      to assistive tech) and the Input becomes the visible control. -->
+      <Dialog.Title class={editingName ? 'sr-only' : 'flex-1 truncate text-lg font-semibold'}>
+        {form.name}
+      </Dialog.Title>
       {#if editingName}
         <Input
           bind:ref={nameInputRef}
@@ -342,10 +348,9 @@
           onkeydown={(e) => {
             if (!isNew && (e.key === 'Enter' || e.key === 'Escape')) stopRenaming()
           }}
+          aria-label={$_('page.plan.itemNameLabel')}
           class="flex-1 text-lg font-semibold"
         />
-      {:else}
-        <Dialog.Title class="flex-1 truncate text-lg font-semibold">{form.name}</Dialog.Title>
       {/if}
 
       {#if !isNew}


### PR DESCRIPTION
## Summary

`AssetEditDialog` and `CashFlowEditDialog` rendered `Dialog.Title` only in the `{:else}` branch of `{#if editingName}`. For new items `editingName` starts `true`, so the dialog opened with no `Dialog.Title` mounted and `Dialog.Content` got no `aria-labelledby` — the modal had no accessible name. Renaming an existing item unmounted the Title while bits-ui kept `titleId`, leaving `aria-labelledby` pointing at a missing element. The rename `Input` also had no accessible name.

- Render `Dialog.Title` unconditionally; apply `sr-only` while editing so it still names the dialog.
- Add a translated `aria-label` to the rename `Input` (new `page.plan.itemNameLabel` key in `cs.json` + `en.json`).
- Applied to both dialogs.

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)