### PR TITLE
perf(stacked-bar-chart): drop dead isSelected/isHovered bar fields

### DIFF
--- a/src/lib/components/stacked-bar-chart.svelte
+++ b/src/lib/components/stacked-bar-chart.svelte
@@ -164,7 +164,6 @@
   const bars = $derived.by(() => {
     return data.map((d, i) => {
       const x = PADDING_LEFT + i * (barWidth + BAR_GAP)
-      const isSelected = d.year === selectedYear
 
       // Calculate heights for each segment
       const cashHeight = scalePositive(d.cash)
@@ -182,8 +181,6 @@
       return {
         year: d.year,
         x,
-        isSelected,
-        isHovered: d.year === hoveredYear,
         segments: [
           // Cash (top of positive stack)
           {


### PR DESCRIPTION
## Summary

The `bars` `$derived.by` in `stacked-bar-chart.svelte` embedded per-bar `isSelected`/`isHovered` fields that are never read anywhere — hover dimming uses `hoveredYear` directly and the indicator lines use separate deriveds via `bars.find()`. Those dead fields made `bars` depend on `selectedYear`/`hoveredYear`, so every hover and every slider drag step rebuilt the entire `bars` array (including rounded-rect path strings) despite unchanged geometry.

- Remove the unused `isSelected`/`isHovered` fields so `bars` depends only on `data` + layout.
- Verified no consumer reads those fields; hover/selection behaviour is unchanged.

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)