### PR TITLE
perf: import lucide icons via per-icon deep imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -54,6 +54,17 @@ export default typescriptEslint.config(
           message: 'Do not import from /index explicitly. Import from the directory instead.',
         },
       ],
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: '@lucide/svelte',
+              message: 'Import icons via deep paths: @lucide/svelte/icons/<name>',
+            },
+          ],
+        },
+      ],
     },
   },
   {

--- a/src/lib/components/editable-item-card.svelte
+++ b/src/lib/components/editable-item-card.svelte
@@ -2,7 +2,11 @@
   import type { Snippet } from 'svelte'
   import { _ } from 'svelte-i18n'
 
-  import { ChevronsUpDown, Copy, EllipsisVertical, SquarePen, Trash2 } from '@lucide/svelte'
+  import ChevronsUpDown from '@lucide/svelte/icons/chevrons-up-down'
+  import Copy from '@lucide/svelte/icons/copy'
+  import EllipsisVertical from '@lucide/svelte/icons/ellipsis-vertical'
+  import SquarePen from '@lucide/svelte/icons/square-pen'
+  import Trash2 from '@lucide/svelte/icons/trash-2'
 
   import { Button } from '$lib/components/ui/button'
   import { Card, CardContent } from '$lib/components/ui/card'

--- a/src/lib/components/expenses-editor.svelte
+++ b/src/lib/components/expenses-editor.svelte
@@ -2,7 +2,7 @@
   import { onDestroy } from 'svelte'
   import { _, locale } from 'svelte-i18n'
 
-  import { Plus } from '@lucide/svelte'
+  import Plus from '@lucide/svelte/icons/plus'
 
   import CashFlowItemCard from '$lib/components/cash-flow-item-card.svelte'
   import { Button } from '$lib/components/ui/button'

--- a/src/lib/components/financial-data-header.svelte
+++ b/src/lib/components/financial-data-header.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import { _ } from 'svelte-i18n'
 
-  import { ArrowLeft, Calendar, SquarePen } from '@lucide/svelte'
+  import ArrowLeft from '@lucide/svelte/icons/arrow-left'
+  import Calendar from '@lucide/svelte/icons/calendar'
+  import SquarePen from '@lucide/svelte/icons/square-pen'
 
   import { resolve } from '$app/paths'
   import { page } from '$app/state'

--- a/src/lib/components/help-tooltip.svelte
+++ b/src/lib/components/help-tooltip.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CircleHelp } from '@lucide/svelte'
+  import CircleHelp from '@lucide/svelte/icons/circle-help'
 
   import * as Tooltip from '$lib/components/ui/tooltip'
   import { cn } from '$lib/utils'

--- a/src/lib/components/incomes-editor.svelte
+++ b/src/lib/components/incomes-editor.svelte
@@ -2,7 +2,7 @@
   import { onDestroy } from 'svelte'
   import { _, locale } from 'svelte-i18n'
 
-  import { Plus } from '@lucide/svelte'
+  import Plus from '@lucide/svelte/icons/plus'
 
   import CashFlowItemCard from '$lib/components/cash-flow-item-card.svelte'
   import SuffixedInput from '$lib/components/suffixed-input.svelte'

--- a/src/lib/components/inflation-adjust-toggle.svelte
+++ b/src/lib/components/inflation-adjust-toggle.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { _ } from 'svelte-i18n'
 
-  import { CircleHelp } from '@lucide/svelte'
+  import CircleHelp from '@lucide/svelte/icons/circle-help'
 
   import { Switch } from '$lib/components/ui/switch'
   import * as Tooltip from '$lib/components/ui/tooltip'

--- a/src/lib/components/investments-editor.svelte
+++ b/src/lib/components/investments-editor.svelte
@@ -2,7 +2,7 @@
   import { onDestroy } from 'svelte'
   import { _ } from 'svelte-i18n'
 
-  import { Plus } from '@lucide/svelte'
+  import Plus from '@lucide/svelte/icons/plus'
 
   import { CATEGORY_COLORS } from '$lib/chart-colors'
   import EditableItemCard from '$lib/components/editable-item-card.svelte'

--- a/src/lib/components/liabilities-editor.svelte
+++ b/src/lib/components/liabilities-editor.svelte
@@ -2,7 +2,7 @@
   import { onDestroy } from 'svelte'
   import { _ } from 'svelte-i18n'
 
-  import { Plus } from '@lucide/svelte'
+  import Plus from '@lucide/svelte/icons/plus'
 
   import { CATEGORY_COLORS } from '$lib/chart-colors'
   import EditableItemCard from '$lib/components/editable-item-card.svelte'

--- a/src/lib/components/navbar.svelte
+++ b/src/lib/components/navbar.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import { _ } from 'svelte-i18n'
 
-  import { EllipsisVertical, FileDown, FileInput } from '@lucide/svelte'
+  import EllipsisVertical from '@lucide/svelte/icons/ellipsis-vertical'
+  import FileDown from '@lucide/svelte/icons/file-down'
+  import FileInput from '@lucide/svelte/icons/file-input'
 
   import { resolve } from '$app/paths'
 

--- a/src/lib/components/onboarding-nav.svelte
+++ b/src/lib/components/onboarding-nav.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { _ } from 'svelte-i18n'
 
-  import { ArrowRight } from '@lucide/svelte'
+  import ArrowRight from '@lucide/svelte/icons/arrow-right'
 
   import { Button } from '$lib/components/ui/button'
 

--- a/src/lib/components/stacked-bar-chart.svelte
+++ b/src/lib/components/stacked-bar-chart.svelte
@@ -64,7 +64,7 @@
 </script>
 
 <script lang="ts">
-  import { TriangleAlert } from '@lucide/svelte'
+  import TriangleAlert from '@lucide/svelte/icons/triangle-alert'
 
   import { CATEGORY_COLORS } from '$lib/chart-colors'
   import * as Tooltip from '$lib/components/ui/tooltip'

--- a/src/lib/components/tangible-assets-editor.svelte
+++ b/src/lib/components/tangible-assets-editor.svelte
@@ -2,7 +2,7 @@
   import { onDestroy } from 'svelte'
   import { _ } from 'svelte-i18n'
 
-  import { Plus } from '@lucide/svelte'
+  import Plus from '@lucide/svelte/icons/plus'
 
   import { CATEGORY_COLORS } from '$lib/chart-colors'
   import EditableItemCard from '$lib/components/editable-item-card.svelte'

--- a/src/lib/components/theme-switcher.svelte
+++ b/src/lib/components/theme-switcher.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import { _ } from 'svelte-i18n'
 
-  import { Monitor, Moon, Sun } from '@lucide/svelte'
+  import Monitor from '@lucide/svelte/icons/monitor'
+  import Moon from '@lucide/svelte/icons/moon'
+  import Sun from '@lucide/svelte/icons/sun'
 
   import { Button } from '$lib/components/ui/button'
   import * as DropdownMenu from '$lib/components/ui/dropdown-menu'

--- a/src/routes/(add-plan)/+layout.svelte
+++ b/src/routes/(add-plan)/+layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { _ } from 'svelte-i18n'
 
-  import { X } from '@lucide/svelte'
+  import X from '@lucide/svelte/icons/x'
 
   import { resolve } from '$app/paths'
   import { page } from '$app/state'

--- a/src/routes/(add-plan)/plan/add/data/+page.svelte
+++ b/src/routes/(add-plan)/plan/add/data/+page.svelte
@@ -2,7 +2,7 @@
   import { _ } from 'svelte-i18n'
   import { SvelteSet } from 'svelte/reactivity'
 
-  import { ArrowRight } from '@lucide/svelte'
+  import ArrowRight from '@lucide/svelte/icons/arrow-right'
 
   import { goto } from '$app/navigation'
   import { resolve } from '$app/paths'

--- a/src/routes/(add-plan)/plan/add/details/+page.svelte
+++ b/src/routes/(add-plan)/plan/add/details/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { _, locale } from 'svelte-i18n'
 
-  import { ArrowRight } from '@lucide/svelte'
+  import ArrowRight from '@lucide/svelte/icons/arrow-right'
 
   import { goto } from '$app/navigation'
 

--- a/src/routes/(add-plan)/plan/add/intro/+page.svelte
+++ b/src/routes/(add-plan)/plan/add/intro/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { _ } from 'svelte-i18n'
 
-  import { ArrowRight } from '@lucide/svelte'
+  import ArrowRight from '@lucide/svelte/icons/arrow-right'
 
   import { goto } from '$app/navigation'
 

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import { _ } from 'svelte-i18n'
 
-  import { ArrowRight, Calendar, Plus, SquarePen } from '@lucide/svelte'
+  import ArrowRight from '@lucide/svelte/icons/arrow-right'
+  import Calendar from '@lucide/svelte/icons/calendar'
+  import Plus from '@lucide/svelte/icons/plus'
+  import SquarePen from '@lucide/svelte/icons/square-pen'
 
   import { resolve } from '$app/paths'
 

--- a/src/routes/(app)/financial-data/+page.svelte
+++ b/src/routes/(app)/financial-data/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { _, locale } from 'svelte-i18n'
 
-  import { SquarePen } from '@lucide/svelte'
+  import SquarePen from '@lucide/svelte/icons/square-pen'
 
   import { resolve } from '$app/paths'
 

--- a/src/routes/(app)/plan/[id]/+page.svelte
+++ b/src/routes/(app)/plan/[id]/+page.svelte
@@ -2,16 +2,14 @@
   import { tick } from 'svelte'
   import { _ } from 'svelte-i18n'
 
-  import {
-    ArrowLeft,
-    ChevronRight,
-    PanelLeft,
-    Plus,
-    Rows2,
-    Search,
-    Settings2,
-    X,
-  } from '@lucide/svelte'
+  import ArrowLeft from '@lucide/svelte/icons/arrow-left'
+  import ChevronRight from '@lucide/svelte/icons/chevron-right'
+  import PanelLeft from '@lucide/svelte/icons/panel-left'
+  import Plus from '@lucide/svelte/icons/plus'
+  import Rows2 from '@lucide/svelte/icons/rows-2'
+  import Search from '@lucide/svelte/icons/search'
+  import Settings2 from '@lucide/svelte/icons/settings-2'
+  import X from '@lucide/svelte/icons/x'
 
   import { resolve } from '$app/paths'
   import { page } from '$app/state'

--- a/src/routes/(app)/plan/[id]/AddAssetDialog.svelte
+++ b/src/routes/(app)/plan/[id]/AddAssetDialog.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { _ } from 'svelte-i18n'
 
-  import { X } from '@lucide/svelte'
+  import X from '@lucide/svelte/icons/x'
 
   import { Button } from '$lib/components/ui/button'
   import * as Dialog from '$lib/components/ui/dialog'

--- a/src/routes/(app)/plan/[id]/AddCashFlowDialog.svelte
+++ b/src/routes/(app)/plan/[id]/AddCashFlowDialog.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { _ } from 'svelte-i18n'
 
-  import { X } from '@lucide/svelte'
+  import X from '@lucide/svelte/icons/x'
 
   import { Button } from '$lib/components/ui/button'
   import * as Dialog from '$lib/components/ui/dialog'

--- a/src/routes/(app)/plan/[id]/AssetEditDialog.svelte
+++ b/src/routes/(app)/plan/[id]/AssetEditDialog.svelte
@@ -1,17 +1,15 @@
 <script lang="ts">
   import { _ } from 'svelte-i18n'
 
-  import {
-    Copy,
-    Eye,
-    EyeOff,
-    Percent,
-    Receipt,
-    Settings2,
-    SquarePen,
-    Trash2,
-    X,
-  } from '@lucide/svelte'
+  import Copy from '@lucide/svelte/icons/copy'
+  import Eye from '@lucide/svelte/icons/eye'
+  import EyeOff from '@lucide/svelte/icons/eye-off'
+  import Percent from '@lucide/svelte/icons/percent'
+  import Receipt from '@lucide/svelte/icons/receipt'
+  import Settings2 from '@lucide/svelte/icons/settings-2'
+  import SquarePen from '@lucide/svelte/icons/square-pen'
+  import Trash2 from '@lucide/svelte/icons/trash-2'
+  import X from '@lucide/svelte/icons/x'
 
   import HelpTooltip from '$lib/components/help-tooltip.svelte'
   import SelectField from '$lib/components/select-field.svelte'

--- a/src/routes/(app)/plan/[id]/CashEditForm.svelte
+++ b/src/routes/(app)/plan/[id]/CashEditForm.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import { _ } from 'svelte-i18n'
 
-  import { Eye, EyeOff, Trash2, X } from '@lucide/svelte'
+  import Eye from '@lucide/svelte/icons/eye'
+  import EyeOff from '@lucide/svelte/icons/eye-off'
+  import Trash2 from '@lucide/svelte/icons/trash-2'
+  import X from '@lucide/svelte/icons/x'
 
   import SuffixedInput from '$lib/components/suffixed-input.svelte'
   import { Button } from '$lib/components/ui/button'

--- a/src/routes/(app)/plan/[id]/CashFlowEditDialog.svelte
+++ b/src/routes/(app)/plan/[id]/CashFlowEditDialog.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
   import { _, locale } from 'svelte-i18n'
 
-  import { Copy, Eye, EyeOff, SquarePen, Trash2, X } from '@lucide/svelte'
+  import Copy from '@lucide/svelte/icons/copy'
+  import Eye from '@lucide/svelte/icons/eye'
+  import EyeOff from '@lucide/svelte/icons/eye-off'
+  import SquarePen from '@lucide/svelte/icons/square-pen'
+  import Trash2 from '@lucide/svelte/icons/trash-2'
+  import X from '@lucide/svelte/icons/x'
 
   import ChangeOverTimeSelector from '$lib/components/change-over-time-selector.svelte'
   import DateAgeSelector from '$lib/components/date-age-selector.svelte'

--- a/src/routes/(app)/plan/[id]/PlanSidebarRow.svelte
+++ b/src/routes/(app)/plan/[id]/PlanSidebarRow.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { _ } from 'svelte-i18n'
 
-  import { TriangleAlert } from '@lucide/svelte'
+  import TriangleAlert from '@lucide/svelte/icons/triangle-alert'
 
   import * as Tooltip from '$lib/components/ui/tooltip'
   import { cn } from '$lib/utils'

--- a/src/routes/(app)/plan/[id]/TransferEditDialog.svelte
+++ b/src/routes/(app)/plan/[id]/TransferEditDialog.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
   import { _, locale } from 'svelte-i18n'
 
-  import { CircleHelp, CopyPlus, Eye, EyeOff, Trash2, X } from '@lucide/svelte'
+  import CircleHelp from '@lucide/svelte/icons/circle-help'
+  import CopyPlus from '@lucide/svelte/icons/copy-plus'
+  import Eye from '@lucide/svelte/icons/eye'
+  import EyeOff from '@lucide/svelte/icons/eye-off'
+  import Trash2 from '@lucide/svelte/icons/trash-2'
+  import X from '@lucide/svelte/icons/x'
 
   import ChangeOverTimeSelector from '$lib/components/change-over-time-selector.svelte'
   import DateAgeSelector from '$lib/components/date-age-selector.svelte'

--- a/src/routes/(onboarding)/+layout.svelte
+++ b/src/routes/(onboarding)/+layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { _ } from 'svelte-i18n'
 
-  import { X } from '@lucide/svelte'
+  import X from '@lucide/svelte/icons/x'
 
   import { resolve } from '$app/paths'
   import { page } from '$app/state'

--- a/src/routes/(onboarding)/finances/edit/+page.svelte
+++ b/src/routes/(onboarding)/finances/edit/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { _ } from 'svelte-i18n'
 
-  import { ArrowRight } from '@lucide/svelte'
+  import ArrowRight from '@lucide/svelte/icons/arrow-right'
 
   import { goto } from '$app/navigation'
   import { resolve } from '$app/paths'

--- a/src/routes/(onboarding)/profile/+page.svelte
+++ b/src/routes/(onboarding)/profile/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { _ } from 'svelte-i18n'
 
-  import { ArrowRight } from '@lucide/svelte'
+  import ArrowRight from '@lucide/svelte/icons/arrow-right'
 
   import { goto } from '$app/navigation'
   import { resolve } from '$app/paths'


### PR DESCRIPTION
## Summary

App code imported icons via the `@lucide/svelte` barrel (~1,600 modules) in ~30 files, while vendored shadcn components already use deep imports. The barrel slows dev-server cold start / HMR and leans on tree-shaking. This standardizes on deep imports and enforces it.

- Convert 30 files from `import { X } from '@lucide/svelte'` to per-icon default deep imports `import X from '@lucide/svelte/icons/x'` (multi-icon imports split into one line per icon). Vendored files already using deep imports are untouched.
- Add a `no-restricted-imports` ESLint rule banning the bare `@lucide/svelte` specifier while still allowing `@lucide/svelte/icons/*`.

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)