### PR TITLE
fix(dev): guard preset load/reset behind confirm + export-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,17 +125,17 @@ Raw data loaded from localStorage is plain JSON. The store "enriches" this data 
 
 ### AppStore Root
 
-| Method / Property     | Description                                     |
-| --------------------- | ----------------------------------------------- |
-| `profile`             | Reactive user profile (name, email, birth_date) |
-| `portfolios`          | Reactive array of all enriched portfolios       |
-| `loading`             | `true` until initial data load completes        |
-| `load()`              | Load from localStorage and enrich all objects   |
-| `reset()`             | Clear all data, set loading to `true`           |
-| `updateProfile(data)` | Update user profile                             |
-| `addPortfolio(data)`  | Add a new portfolio, returns ID                 |
-| `exportBackup()`      | JSON string of all data                         |
-| `importBackup(json)`  | Import and enrich from JSON string              |
+| Method / Property     | Description                                      |
+| --------------------- | ------------------------------------------------ |
+| `profile`             | Reactive user profile (name, email, birth_date)  |
+| `portfolios`          | Reactive array of all enriched portfolios        |
+| `loading`             | `true` until initial data load completes         |
+| `load()`              | Load from localStorage and enrich all objects    |
+| `clear()`             | Wipe all data and persisted storage, ready state |
+| `updateProfile(data)` | Update user profile                              |
+| `addPortfolio(data)`  | Add a new portfolio, returns ID                  |
+| `exportBackup()`      | JSON string of all data                          |
+| `importBackup(json)`  | Import and enrich from JSON string               |
 
 ### PortfolioStore
 

--- a/src/lib/locales/cs.json
+++ b/src/lib/locales/cs.json
@@ -395,6 +395,16 @@
       "visitGithub": "Navštívit náš GitHub"
     }
   },
+  "dev": {
+    "confirm": {
+      "title": "Nahradit všechna vaše data?",
+      "description": "Načtení této předlohy přepíše všechna data aktuálně uložená v tomto prohlížeči.",
+      "warning": "Vaše stávající data budou nejprve exportována do souboru, abyste je mohli později obnovit.",
+      "cancel": "Zrušit",
+      "exportAndContinue": "Exportovat a pokračovat",
+      "continue": "Pokračovat"
+    }
+  },
   "validation": {
     "required_when_start_at_specific_date": "Povinné, když začátek je v konkrétní datum",
     "required_when_start_when_age_is": "Povinné, když začátek je při dosažení věku",

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -395,6 +395,16 @@
       "visitGithub": "Visit our Github"
     }
   },
+  "dev": {
+    "confirm": {
+      "title": "Replace all your data?",
+      "description": "Loading this preset overwrites all data currently stored in this browser.",
+      "warning": "Your current data will be exported to a file first so you can restore it later.",
+      "cancel": "Cancel",
+      "exportAndContinue": "Export and continue",
+      "continue": "Continue"
+    }
+  },
   "validation": {
     "required_when_start_at_specific_date": "Required when start is at a specific date",
     "required_when_start_when_age_is": "Required when start is at a specific age",

--- a/src/lib/stores/app.svelte.test.ts
+++ b/src/lib/stores/app.svelte.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import storageKeys from '$lib/storage-keys'
+
+import { appStore } from './app.svelte'
+
+describe('appStore.clear', () => {
+  let backing: Map<string, string>
+
+  beforeEach(() => {
+    backing = new Map<string, string>()
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => (backing.has(key) ? backing.get(key) : undefined),
+      setItem: (key: string, value: string) => {
+        backing.set(key, value)
+      },
+      removeItem: (key: string) => {
+        backing.delete(key)
+      },
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('wipes in-memory data, persisted storage, and clears the loading flag', () => {
+    appStore.importBackup(
+      JSON.stringify({ profile: { name: 'Jane Doe', email: '' }, portfolios: [] }),
+    )
+    expect(appStore.profile.name).toBe('Jane Doe')
+    expect(backing.has(storageKeys.DATA)).toBe(true)
+
+    appStore.clear()
+
+    expect(appStore.profile.name).toBe('')
+    expect(appStore.portfolios).toEqual([])
+    expect(appStore.loading).toBe(false)
+    expect(backing.has(storageKeys.DATA)).toBe(false)
+  })
+})

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -175,10 +175,18 @@ function withAppStore() {
     set loading(value: boolean) {
       loading = value
     },
-    reset() {
+    clear() {
       profile = enrichProfile({ ...DEFAULT_PROFILE })
       portfolios = []
-      loading = true
+      lastUpdated = 0
+      try {
+        localStorage.removeItem(storageKeys.DATA)
+        storageErrorStore.clear()
+      } catch (e) {
+        console.error('Failed to clear data from localStorage', e)
+        storageErrorStore.setError()
+      }
+      loading = false
     },
 
     persist,

--- a/src/routes/dev/+page.svelte
+++ b/src/routes/dev/+page.svelte
@@ -1,12 +1,16 @@
 <!-- localization-exclude -->
 <script lang="ts">
+  import { _ } from 'svelte-i18n'
+
+  import FileDown from '@lucide/svelte/icons/file-down'
+
   import { goto } from '$app/navigation'
   import { resolve } from '$app/paths'
 
   import { CATEGORY_COLORS } from '$lib/chart-colors'
   import { Button } from '$lib/components/ui/button'
+  import * as Dialog from '$lib/components/ui/dialog'
   import routes from '$lib/routes'
-  import storageKeys from '$lib/storage-keys'
   import { appStore } from '$lib/stores/app.svelte'
 
   const colorCategories = [
@@ -414,15 +418,47 @@
     },
   ]
 
-  function loadPreset(preset: (typeof presets)[number]) {
+  const hasData = $derived(!appStore.loading && !!appStore.profile.name)
+
+  let confirmOpen = $state(false)
+  let pendingPreset = $state<(typeof presets)[number] | undefined>(undefined)
+
+  // Mirrors the navbar export flow: download the current data as a JSON backup.
+  function exportData(): void {
+    const json = appStore.exportBackup()
+    const blob = new Blob([json], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `kalkul-backup-${new Date().toISOString().slice(0, 10)}.json`
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    // Delay revoke so the browser has time to start the download.
+    setTimeout(() => URL.revokeObjectURL(url), 1000)
+  }
+
+  function requestLoadPreset(preset: (typeof presets)[number]): void {
+    pendingPreset = preset
+    confirmOpen = true
+  }
+
+  function applyPreset(preset: (typeof presets)[number]): void {
     if (preset.data.profile.name === '') {
-      appStore.reset()
-      localStorage.removeItem(storageKeys.DATA)
-      appStore.loading = false
+      appStore.clear()
     } else {
       appStore.importBackup(JSON.stringify(preset.data))
     }
     goto(resolve(routes.HOME))
+  }
+
+  // Export-first: back up any existing data before the destructive action.
+  function confirmLoadPreset(): void {
+    const preset = pendingPreset
+    if (!preset) return
+    if (hasData) exportData()
+    confirmOpen = false
+    applyPreset(preset)
   }
 
   const profileJson = $derived(JSON.stringify(appStore.profile.toJSON(), undefined, 2))
@@ -439,7 +475,7 @@
           <span class="font-medium">{preset.name}</span>
           <span class="text-sm text-muted-foreground">{preset.description}</span>
         </div>
-        <Button size="sm" onclick={() => loadPreset(preset)}>Load</Button>
+        <Button size="sm" onclick={() => requestLoadPreset(preset)}>Load</Button>
       </div>
     {/each}
   </div>
@@ -468,3 +504,33 @@
     <pre class="max-h-96 overflow-auto rounded-lg bg-muted p-4 text-xs">{profileJson}</pre>
   </div>
 </div>
+
+<!-- Confirm destructive preset load (export-first, like the navbar import flow) -->
+<Dialog.Root bind:open={confirmOpen}>
+  <Dialog.Content class="sm:max-w-[576px]">
+    <Dialog.Header>
+      <Dialog.Title>{$_('dev.confirm.title')}</Dialog.Title>
+      <Dialog.Description class="text-base text-foreground">
+        {$_('dev.confirm.description')}
+      </Dialog.Description>
+    </Dialog.Header>
+    {#if hasData}
+      <p class="text-base font-bold text-foreground">
+        {$_('dev.confirm.warning')}
+      </p>
+    {/if}
+    <Dialog.Footer class="sm:justify-start">
+      <Button variant="outline" onclick={() => (confirmOpen = false)}>
+        {$_('dev.confirm.cancel')}
+      </Button>
+      <Button variant="destructive" onclick={confirmLoadPreset}>
+        {#if hasData}
+          <FileDown class="size-4" />
+          {$_('dev.confirm.exportAndContinue')}
+        {:else}
+          {$_('dev.confirm.continue')}
+        {/if}
+      </Button>
+    </Dialog.Footer>
+  </Dialog.Content>
+</Dialog.Root>


### PR DESCRIPTION
## Summary

The `/dev` page ships in every build, and each preset's Load button cleared or overwrote all of localStorage with **one unconfirmed click** — in a local-first app where localStorage is the only copy, that's one click from irreversible data loss. The page also reached around the store API (`localStorage.removeItem` + forcing `loading = false`).

This makes the destructive paths safe without removing the page from production (PR previews are production builds and may use the presets):

- **Confirmation dialog** before every destructive preset action, reusing the same `Dialog` component/pattern the navbar import flow uses.
- **Automatic export-first**: the current data is downloaded as a backup (navbar's `exportData` flow) before applying a preset, gated on there being data to export.
- **`appStore.clear()`**: a proper store method (mirrors the existing `persist()` error handling) replaces the raw `removeItem` + `loading` poking. The now-unused `reset()` was removed and its README row updated.
- New `dev.confirm.*` locale keys added to `cs.json` + `en.json`; a `clear()` unit test added.

Closes #108

### Notes / deviations
- Removed the previously-unused `appStore.reset()` (the method the buggy path relied on) rather than leaving dead code; `pnpm check` + `knip` confirm nothing else referenced it.
- Verified via worktree dev-server compile/serve, the `clear()` unit test, and svelte-check. A live click-through of the dialog wasn't possible because the preview server runs from the main checkout, not the worktree; the dialog markup mirrors the navbar's working `Dialog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)