### PR TITLE
feat: .kalkul.json backups with profile name + example profiles

### DIFF
--- a/examples/bence-toth-hu-25yo.kalkul.json
+++ b/examples/bence-toth-hu-25yo.kalkul.json
@@ -1,0 +1,114 @@
+{
+  "profile": {
+    "name": "Bence Tóth",
+    "email": "bence.toth@example.com",
+    "birth_date": "2001-09-03",
+    "location": "HU",
+    "currency": "HUF",
+    "cash_amount": 1450000,
+    "has_investments": true,
+    "investments": [
+      {
+        "id": "inv-1",
+        "name": "Robo-advisor portfolio",
+        "balance": 2100000,
+        "apy": 6.5,
+        "entry_fee": 0.75,
+        "entry_fee_type": "upfront"
+      }
+    ],
+    "has_tangible_assets": true,
+    "tangible_assets": [
+      {
+        "id": "ta-1",
+        "name": "Car (Suzuki Vitara)",
+        "value": 6800000,
+        "status": "financed",
+        "outstanding_balance": 4200000,
+        "installment_frequency": "monthly",
+        "annual_rate": 9.5,
+        "installment_amount": 115000,
+        "remaining_term": 4
+      }
+    ],
+    "has_liabilities": true,
+    "liabilities": [
+      {
+        "id": "li-1",
+        "name": "Student loan (Diákhitel)",
+        "outstanding_balance": 1800000,
+        "installment_frequency": "monthly",
+        "annual_rate": 4.5,
+        "installment_amount": 28000,
+        "remaining_term": 6,
+        "interest_type": "simple"
+      }
+    ],
+    "incomes": [
+      {
+        "id": "inc-1",
+        "name": "Salary (software tester)",
+        "amount": 720000,
+        "frequency": "monthly",
+        "withhold_taxes": true,
+        "tax_percentage": 33.5,
+        "start": "immediately",
+        "end": "never",
+        "inflation_adjusted": true,
+        "change_over_time": "increase_yearly",
+        "change_percentage": 3
+      },
+      {
+        "id": "inc-2",
+        "name": "Weekend DJ gigs",
+        "amount": 60000,
+        "frequency": "monthly",
+        "withhold_taxes": false,
+        "start": "immediately",
+        "end": "when_age_is",
+        "end_age": 30,
+        "change_over_time": "none"
+      }
+    ],
+    "expenses": [
+      {
+        "id": "exp-1",
+        "name": "Rent (Budapest flat)",
+        "amount": 230000,
+        "frequency": "monthly",
+        "start": "immediately",
+        "end": "never",
+        "change_over_time": "match_inflation"
+      },
+      {
+        "id": "exp-2",
+        "name": "Food & everyday costs",
+        "amount": 160000,
+        "frequency": "monthly",
+        "start": "immediately",
+        "end": "never",
+        "change_over_time": "match_inflation"
+      },
+      {
+        "id": "exp-3",
+        "name": "Streaming & gym subscriptions",
+        "amount": 18000,
+        "frequency": "monthly",
+        "start": "immediately",
+        "end": "never",
+        "change_over_time": "none"
+      },
+      {
+        "id": "exp-4",
+        "name": "Summer festival trip",
+        "amount": 250000,
+        "frequency": "yearly",
+        "start": "immediately",
+        "end": "when_age_is",
+        "end_age": 35,
+        "change_over_time": "none"
+      }
+    ]
+  },
+  "portfolios": []
+}

--- a/examples/claire-moreau-fr-40yo.kalkul.json
+++ b/examples/claire-moreau-fr-40yo.kalkul.json
@@ -1,0 +1,188 @@
+{
+  "profile": {
+    "name": "Claire Moreau",
+    "email": "claire.moreau@example.com",
+    "birth_date": "1986-05-27",
+    "location": "FR",
+    "currency": "EUR",
+    "cash_amount": 28000,
+    "has_investments": true,
+    "investments": [
+      {
+        "id": "inv-1",
+        "name": "World ETF (PEA)",
+        "balance": 96000,
+        "apy": 7,
+        "ter": 0.25,
+        "exit_fee": 0.5,
+        "exit_fee_type": "percentage"
+      },
+      {
+        "id": "inv-2",
+        "name": "Company pension plan (PER)",
+        "balance": 41000,
+        "apy": 4.5,
+        "entry_fee": 2,
+        "entry_fee_type": "forty-sixty"
+      },
+      {
+        "id": "inv-3",
+        "name": "Livret A savings",
+        "balance": 22000,
+        "apy": 2.4
+      }
+    ],
+    "has_tangible_assets": true,
+    "tangible_assets": [
+      {
+        "id": "ta-1",
+        "name": "Family house (Lyon)",
+        "value": 420000,
+        "status": "financed",
+        "outstanding_balance": 235000,
+        "installment_frequency": "monthly",
+        "annual_rate": 2.1,
+        "installment_amount": 1350,
+        "remaining_term": 17
+      },
+      {
+        "id": "ta-2",
+        "name": "Rental apartment (Villeurbanne)",
+        "value": 190000,
+        "status": "financed",
+        "outstanding_balance": 98000,
+        "installment_frequency": "monthly",
+        "annual_rate": 2.8,
+        "installment_amount": 780,
+        "remaining_term": 12
+      },
+      {
+        "id": "ta-3",
+        "name": "Car (Peugeot 5008)",
+        "value": 21000,
+        "status": "fully_owned"
+      }
+    ],
+    "has_liabilities": true,
+    "liabilities": [
+      {
+        "id": "li-1",
+        "name": "Home renovation loan",
+        "outstanding_balance": 14500,
+        "installment_frequency": "monthly",
+        "annual_rate": 5.2,
+        "installment_amount": 320,
+        "remaining_term": 4,
+        "interest_type": "compound",
+        "compounding_frequency": "monthly"
+      }
+    ],
+    "incomes": [
+      {
+        "id": "inc-1",
+        "name": "Salary (marketing manager)",
+        "amount": 4600,
+        "frequency": "monthly",
+        "withhold_taxes": true,
+        "tax_percentage": 27,
+        "start": "immediately",
+        "end": "never",
+        "change_over_time": "match_inflation"
+      },
+      {
+        "id": "inc-2",
+        "name": "Rental income (Villeurbanne)",
+        "amount": 850,
+        "frequency": "monthly",
+        "withhold_taxes": true,
+        "tax_percentage": 30,
+        "start": "immediately",
+        "end": "never",
+        "change_over_time": "match_inflation"
+      }
+    ],
+    "expenses": [
+      {
+        "id": "exp-1",
+        "name": "Household & groceries",
+        "amount": 1900,
+        "frequency": "monthly",
+        "start": "immediately",
+        "end": "never",
+        "change_over_time": "match_inflation"
+      },
+      {
+        "id": "exp-2",
+        "name": "Children's school & activities",
+        "amount": 520,
+        "frequency": "monthly",
+        "start": "immediately",
+        "end": "at_specific_date",
+        "end_year": 2036,
+        "end_month": 6,
+        "change_over_time": "match_inflation"
+      },
+      {
+        "id": "exp-3",
+        "name": "Rental property upkeep",
+        "amount": 1800,
+        "frequency": "yearly",
+        "start": "immediately",
+        "end": "never",
+        "change_over_time": "match_inflation"
+      },
+      {
+        "id": "exp-4",
+        "name": "Insurance (home, car, health)",
+        "amount": 260,
+        "frequency": "monthly",
+        "start": "immediately",
+        "end": "never",
+        "change_over_time": "none"
+      },
+      {
+        "id": "exp-5",
+        "name": "Family holidays",
+        "amount": 4500,
+        "frequency": "yearly",
+        "start": "immediately",
+        "end": "never",
+        "change_over_time": "none"
+      }
+    ]
+  },
+  "portfolios": [
+    {
+      "id": "plan-1",
+      "name": "Family plan to 65",
+      "notes": "Keep investing monthly into the ETF until retirement; rental apartment carries itself.",
+      "start_date": "2026-07-01",
+      "end_date": "2051-05-01",
+      "inflation_rate": 0.02,
+      "include_cash": true,
+      "included_investment_ids": ["inv-1", "inv-2", "inv-3"],
+      "included_tangible_asset_ids": ["ta-1", "ta-2"],
+      "included_liability_ids": ["li-1"],
+      "included_income_ids": ["inc-1", "inc-2"],
+      "included_expense_ids": ["exp-1", "exp-2", "exp-3", "exp-4", "exp-5"],
+      "transfers": [
+        {
+          "id": "tr-1",
+          "name": "Monthly ETF contribution",
+          "from_asset_id": "cash",
+          "to_asset_id": "inv-1",
+          "amount": 600,
+          "schedule": "recurring",
+          "frequency": "monthly",
+          "start": "immediately",
+          "end": "when_age_is",
+          "end_age": 65,
+          "change_over_time": "match_inflation"
+        }
+      ],
+      "included_transfer_ids": ["tr-1"],
+      "investments": [],
+      "goals": []
+    }
+  ]
+}

--- a/examples/martin-kovac-sk-30yo.kalkul.json
+++ b/examples/martin-kovac-sk-30yo.kalkul.json
@@ -1,0 +1,110 @@
+{
+  "profile": {
+    "name": "Martin Kováč",
+    "email": "martin.kovac@example.com",
+    "birth_date": "1996-04-12",
+    "location": "SK",
+    "currency": "EUR",
+    "cash_amount": 9500,
+    "has_investments": true,
+    "investments": [
+      {
+        "id": "inv-1",
+        "name": "World ETF portfolio",
+        "balance": 21000,
+        "apy": 7,
+        "ter": 0.22
+      },
+      {
+        "id": "inv-2",
+        "name": "Third-pillar pension savings",
+        "balance": 7800,
+        "apy": 4.5
+      }
+    ],
+    "has_tangible_assets": true,
+    "tangible_assets": [
+      {
+        "id": "ta-1",
+        "name": "House",
+        "value": 185000,
+        "status": "financed",
+        "outstanding_balance": 128000,
+        "installment_frequency": "monthly",
+        "annual_rate": 3.9,
+        "installment_amount": 670,
+        "remaining_term": 25
+      },
+      {
+        "id": "ta-2",
+        "name": "Car (Škoda Octavia)",
+        "value": 11500,
+        "status": "fully_owned"
+      }
+    ],
+    "has_liabilities": true,
+    "liabilities": [
+      {
+        "id": "li-1",
+        "name": "Consumer loan (furniture)",
+        "outstanding_balance": 3200,
+        "installment_frequency": "monthly",
+        "annual_rate": 8.9,
+        "installment_amount": 160,
+        "remaining_term": 2
+      }
+    ],
+    "incomes": [
+      {
+        "id": "inc-1",
+        "name": "Salary",
+        "amount": 3000,
+        "frequency": "monthly",
+        "withhold_taxes": true,
+        "tax_percentage": 25,
+        "start": "immediately",
+        "end": "never",
+        "change_over_time": "match_inflation"
+      }
+    ],
+    "expenses": [
+      {
+        "id": "exp-1",
+        "name": "Living costs",
+        "amount": 850,
+        "frequency": "monthly",
+        "start": "immediately",
+        "end": "never",
+        "change_over_time": "match_inflation"
+      },
+      {
+        "id": "exp-2",
+        "name": "Car & transport",
+        "amount": 150,
+        "frequency": "monthly",
+        "start": "immediately",
+        "end": "never",
+        "change_over_time": "match_inflation"
+      },
+      {
+        "id": "exp-3",
+        "name": "Insurance",
+        "amount": 60,
+        "frequency": "monthly",
+        "start": "immediately",
+        "end": "never",
+        "change_over_time": "none"
+      },
+      {
+        "id": "exp-4",
+        "name": "Travel & leisure",
+        "amount": 1500,
+        "frequency": "yearly",
+        "start": "immediately",
+        "end": "never",
+        "change_over_time": "none"
+      }
+    ]
+  },
+  "portfolios": []
+}

--- a/examples/pavel-dvorak-cz-50yo.kalkul.json
+++ b/examples/pavel-dvorak-cz-50yo.kalkul.json
@@ -1,0 +1,167 @@
+{
+  "profile": {
+    "name": "Pavel Dvořák",
+    "email": "pavel.dvorak@example.com",
+    "birth_date": "1976-11-08",
+    "location": "CZ",
+    "currency": "CZK",
+    "cash_amount": 850000,
+    "has_investments": true,
+    "investments": [
+      {
+        "id": "inv-1",
+        "name": "Global equity ETF",
+        "balance": 3900000,
+        "apy": 6.5,
+        "ter": 0.2
+      },
+      {
+        "id": "inv-2",
+        "name": "Government bond fund",
+        "balance": 1600000,
+        "apy": 3.8,
+        "exit_fee": 500,
+        "exit_fee_type": "fixed"
+      },
+      {
+        "id": "inv-3",
+        "name": "Building savings (stavební spoření)",
+        "balance": 420000,
+        "apy": 2.5
+      }
+    ],
+    "has_tangible_assets": true,
+    "tangible_assets": [
+      {
+        "id": "ta-1",
+        "name": "House (Brno)",
+        "value": 9500000,
+        "status": "fully_owned"
+      },
+      {
+        "id": "ta-2",
+        "name": "Cottage (Vysočina)",
+        "value": 2800000,
+        "status": "fully_owned"
+      },
+      {
+        "id": "ta-3",
+        "name": "Car (Škoda Superb)",
+        "value": 550000,
+        "status": "fully_owned"
+      }
+    ],
+    "has_liabilities": false,
+    "incomes": [
+      {
+        "id": "inc-1",
+        "name": "Salary (senior engineer)",
+        "amount": 95000,
+        "frequency": "monthly",
+        "withhold_taxes": true,
+        "tax_percentage": 26,
+        "start": "immediately",
+        "end": "when_age_is",
+        "end_age": 65,
+        "change_over_time": "match_inflation"
+      },
+      {
+        "id": "inc-2",
+        "name": "State pension",
+        "amount": 24000,
+        "frequency": "monthly",
+        "withhold_taxes": false,
+        "start": "when_age_is",
+        "start_age": 65,
+        "end": "never",
+        "change_over_time": "match_inflation"
+      }
+    ],
+    "expenses": [
+      {
+        "id": "exp-1",
+        "name": "Household & living",
+        "amount": 38000,
+        "frequency": "monthly",
+        "start": "immediately",
+        "end": "never",
+        "change_over_time": "match_inflation"
+      },
+      {
+        "id": "exp-2",
+        "name": "Active lifestyle (travel, hobbies)",
+        "amount": 180000,
+        "frequency": "yearly",
+        "start": "immediately",
+        "end": "never",
+        "change_over_time": "decrease_yearly",
+        "change_percentage": 2
+      },
+      {
+        "id": "exp-3",
+        "name": "Cottage maintenance",
+        "amount": 45000,
+        "frequency": "yearly",
+        "start": "immediately",
+        "end": "never",
+        "change_over_time": "match_inflation"
+      },
+      {
+        "id": "exp-4",
+        "name": "Support for daughter at university",
+        "amount": 12000,
+        "frequency": "monthly",
+        "start": "immediately",
+        "end": "at_specific_date",
+        "end_year": 2030,
+        "end_month": 6,
+        "change_over_time": "none"
+      }
+    ]
+  },
+  "portfolios": [
+    {
+      "id": "plan-1",
+      "name": "Retirement at 65",
+      "notes": "Shift building savings into bonds at retirement, then draw down the ETF monthly.",
+      "start_date": "2026-07-01",
+      "end_date": "2066-11-01",
+      "inflation_rate": 0.025,
+      "include_cash": true,
+      "included_investment_ids": ["inv-1", "inv-2", "inv-3"],
+      "included_tangible_asset_ids": ["ta-1", "ta-2"],
+      "included_income_ids": ["inc-1", "inc-2"],
+      "included_expense_ids": ["exp-1", "exp-2", "exp-3", "exp-4"],
+      "transfers": [
+        {
+          "id": "tr-1",
+          "name": "Move building savings to bonds at retirement",
+          "from_asset_id": "inv-3",
+          "to_asset_id": "inv-2",
+          "amount": 0,
+          "transfer_all": true,
+          "schedule": "one_time",
+          "transaction_year": 2041,
+          "transaction_month": 11
+        },
+        {
+          "id": "tr-2",
+          "name": "Monthly pension top-up from ETF",
+          "from_asset_id": "inv-1",
+          "to_asset_id": "cash",
+          "amount": 30000,
+          "inflation_adjusted": true,
+          "schedule": "recurring",
+          "frequency": "monthly",
+          "start": "when_age_is",
+          "start_age": 65,
+          "end": "never",
+          "change_over_time": "none"
+        }
+      ],
+      "included_transfer_ids": ["tr-1", "tr-2"],
+      "investments": [],
+      "goals": []
+    }
+  ]
+}

--- a/examples/tereza-svobodova-cz-20yo.kalkul.json
+++ b/examples/tereza-svobodova-cz-20yo.kalkul.json
@@ -1,0 +1,90 @@
+{
+  "profile": {
+    "name": "Tereza Svobodová",
+    "email": "tereza.svobodova@example.com",
+    "birth_date": "2006-02-18",
+    "location": "CZ",
+    "currency": "CZK",
+    "cash_amount": 48000,
+    "incomes": [
+      {
+        "id": "inc-1",
+        "name": "Part-time job (café)",
+        "amount": 2800,
+        "frequency": "weekly",
+        "withhold_taxes": false,
+        "start": "immediately",
+        "end": "at_specific_date",
+        "end_year": 2029,
+        "end_month": 6,
+        "change_over_time": "none"
+      },
+      {
+        "id": "inc-2",
+        "name": "Allowance from parents",
+        "amount": 4000,
+        "frequency": "monthly",
+        "withhold_taxes": false,
+        "start": "immediately",
+        "end": "when_age_is",
+        "end_age": 24,
+        "change_over_time": "none"
+      },
+      {
+        "id": "inc-3",
+        "name": "First full-time salary",
+        "amount": 42000,
+        "frequency": "monthly",
+        "withhold_taxes": true,
+        "tax_percentage": 21,
+        "start": "at_specific_date",
+        "start_year": 2029,
+        "start_month": 7,
+        "end": "never",
+        "change_over_time": "increase_yearly",
+        "change_percentage": 4
+      }
+    ],
+    "expenses": [
+      {
+        "id": "exp-1",
+        "name": "Shared flat rent",
+        "amount": 8500,
+        "frequency": "monthly",
+        "start": "immediately",
+        "end": "never",
+        "change_over_time": "increase_yearly",
+        "change_percentage": 5
+      },
+      {
+        "id": "exp-2",
+        "name": "Food & living",
+        "amount": 6000,
+        "frequency": "monthly",
+        "start": "immediately",
+        "end": "never",
+        "change_over_time": "match_inflation"
+      },
+      {
+        "id": "exp-3",
+        "name": "Student transport pass",
+        "amount": 1280,
+        "frequency": "yearly",
+        "start": "immediately",
+        "end": "when_age_is",
+        "end_age": 26,
+        "change_over_time": "none"
+      },
+      {
+        "id": "exp-4",
+        "name": "Phone & subscriptions",
+        "amount": 550,
+        "frequency": "monthly",
+        "start": "immediately",
+        "end": "never",
+        "change_over_time": "none"
+      }
+    ]
+  },
+  "portfolios": []
+}

--- a/src/lib/components/navbar.svelte
+++ b/src/lib/components/navbar.svelte
@@ -17,6 +17,7 @@
   import externalLinks from '$lib/external-links'
   import routes from '$lib/routes'
   import { appStore } from '$lib/stores/app.svelte'
+  import { slugify } from '$lib/utils'
 
   const hasData = $derived(!appStore.loading && !!appStore.profile.name)
 
@@ -37,7 +38,8 @@
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url
-    a.download = `kalkul-backup-${new Date().toISOString().slice(0, 10)}.json`
+    const nameSlug = slugify(appStore.profile.name)
+    a.download = `kalkul-backup-${nameSlug ? `${nameSlug}-` : ''}${new Date().toISOString().slice(0, 10)}.kalkul.json`
     document.body.appendChild(a)
     a.click()
     document.body.removeChild(a)
@@ -138,7 +140,7 @@
 <input
   bind:this={fileInput}
   type="file"
-  accept="application/json,.json"
+  accept=".kalkul.json"
   class="hidden"
   onchange={handleFileSelect}
 />

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -7,8 +7,25 @@ import {
   formatNumber,
   getFormattingLocale,
   parseDateOnly,
+  slugify,
   toDateOnlyString,
 } from './utils'
+
+describe('slugify', () => {
+  it('lowercases and strips accents', () => {
+    expect(slugify('Martin Kováč')).toBe('martin-kovac')
+    expect(slugify('Tereza Svobodová')).toBe('tereza-svobodova')
+  })
+
+  it('collapses non-alphanumerics and trims dashes', () => {
+    expect(slugify('  Bence Tóth (jr.) & co!  ')).toBe('bence-toth-jr-co')
+  })
+
+  it('returns an empty string when nothing survives', () => {
+    expect(slugify('  ')).toBe('')
+    expect(slugify('***')).toBe('')
+  })
+})
 
 describe('getFormattingLocale', () => {
   it('maps a known country to its locale', () => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -16,6 +16,16 @@ export type WithoutChildrenOrChild<T> = T extends { children?: infer _C; child?:
   ? Omit<T, 'children' | 'child'>
   : T
 
+/** Filename-safe slug: lowercase, accents stripped, non-alphanumerics collapsed to dashes. */
+export function slugify(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
 export const DEFAULT_CURRENCY = 'EUR'
 
 export const CURRENCY_OPTIONS = [

--- a/src/routes/dev/+page.svelte
+++ b/src/routes/dev/+page.svelte
@@ -12,6 +12,7 @@
   import * as Dialog from '$lib/components/ui/dialog'
   import routes from '$lib/routes'
   import { appStore } from '$lib/stores/app.svelte'
+  import { slugify } from '$lib/utils'
 
   const colorCategories = [
     { name: 'Cash', colors: [CATEGORY_COLORS.cash] },
@@ -430,7 +431,8 @@
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url
-    a.download = `kalkul-backup-${new Date().toISOString().slice(0, 10)}.json`
+    const nameSlug = slugify(appStore.profile.name)
+    a.download = `kalkul-backup-${nameSlug ? `${nameSlug}-` : ''}${new Date().toISOString().slice(0, 10)}.kalkul.json`
     document.body.appendChild(a)
     a.click()
     document.body.removeChild(a)


### PR DESCRIPTION
## Summary

- Backup exports are now named `kalkul-backup-<name>-<date>.kalkul.json` — the profile name is slugified (lowercase, accents stripped, non-alphanumerics collapsed to dashes) via a new `slugify()` helper in `src/lib/utils.ts`, and the `.kalkul.json` extension makes exports easy to find without matching every `.json` file
- The import file picker now filters to `.kalkul.json` (no backwards compatibility needed pre-production; Zod still validates whatever is imported)
- New `examples/` folder with five schema-valid profiles (`<name>-<country>-<age>yo.kalkul.json`, ages 20–50) that together exercise every enum branch the profile/plan schemas support: all frequencies, start/end modes, change-over-time variants, entry/exit fee types, simple/compound interest, financed assets, and plans with recurring, one-time, and transfer-all transfers

## Test plan

- [x] `slugify` unit tests (accents, punctuation collapse, empty input)
- [x] All example files validated against `storedDataSchema`
- [x] `pnpm check:all`
- [x] Manual: export from navbar → filename includes slugged name; re-import the file via the picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)