### PR TITLE
fix: show frequency time unit on cash-flow card amounts

### DIFF
--- a/src/lib/components/cash-flow-item-card.svelte
+++ b/src/lib/components/cash-flow-item-card.svelte
@@ -11,7 +11,7 @@
   import { Separator } from '$lib/components/ui/separator'
   import { Switch } from '$lib/components/ui/switch'
   import type { CashFlowEnd, CashFlowStart, ChangeOverTime, Frequency } from '$lib/schemas'
-  import { getFrequencyItems } from '$lib/select-options'
+  import { getFrequencyItems, getFrequencyShortLabel } from '$lib/select-options'
 
   interface CashFlowItem {
     id: string
@@ -77,7 +77,7 @@
   let collapsedValueClass = $derived(sentiment === 'positive' ? 'text-success' : 'text-destructive')
   let formattedAmount = $derived.by(() => {
     if (item.amount === undefined || item.amount === 0) return ''
-    return `${sign}${formatCurrency(item.amount)}`
+    return `${sign}${formatCurrency(item.amount)} / ${getFrequencyShortLabel($_, item.frequency)}`
   })
 </script>
 

--- a/src/lib/select-options.ts
+++ b/src/lib/select-options.ts
@@ -23,6 +23,12 @@ export function getFrequencyItems($_: Translator): SelectFieldItem[] {
   return frequencySchema.options.map((value) => ({ value, label: labels[value] }))
 }
 
+export function getFrequencyShortLabel($_: Translator, frequency: Frequency): string {
+  if (frequency === 'monthly') return $_('page.financialData.frequency.short.monthly')
+  if (frequency === 'weekly') return $_('page.financialData.frequency.short.weekly')
+  return $_('page.financialData.frequency.short.yearly')
+}
+
 export function getTangibleAssetStatusItems($_: Translator): SelectFieldItem[] {
   const labels = {
     fully_owned: $_('page.setup.tangibleAssets.fullyOwned'),

--- a/src/routes/(app)/plan/[id]/+page.svelte
+++ b/src/routes/(app)/plan/[id]/+page.svelte
@@ -34,13 +34,13 @@
   import routes from '$lib/routes'
   import type {
     Expense,
-    Frequency,
     Income,
     ProfileInvestment,
     ProfileLiability,
     ProfileTangibleAsset,
     Transfer,
   } from '$lib/schemas'
+  import { getFrequencyShortLabel } from '$lib/select-options'
   import { appStore } from '$lib/stores/app.svelte'
   import { cn, notImplemented } from '$lib/utils'
 
@@ -193,7 +193,7 @@
 
   function transferValueSuffix(t: Transfer): string {
     if (t.schedule === 'one_time') return `(${$_('page.plan.scheduleOneTime').toLowerCase()})`
-    return `/ ${frequencySuffix(t.frequency ?? 'monthly')}`
+    return `/ ${getFrequencyShortLabel($_, t.frequency ?? 'monthly')}`
   }
   const incomesCount = $derived((appStore.profile.incomes ?? []).length)
   const expensesCount = $derived((appStore.profile.expenses ?? []).length)
@@ -230,13 +230,6 @@
   const tangibleAssetsValue = $derived(selectedYearProjection?.tangibleAssets ?? 0)
   const liabilitiesValue = $derived(selectedYearProjection?.liabilities ?? 0)
   const netWorth = $derived(selectedYearProjection?.netWorth ?? 0)
-
-  // Per-frequency short suffix for cash-flow rows
-  function frequencySuffix(frequency: Frequency): string {
-    if (frequency === 'monthly') return $_('page.financialData.frequency.short.monthly')
-    if (frequency === 'weekly') return $_('page.financialData.frequency.short.weekly')
-    return $_('page.financialData.frequency.short.yearly')
-  }
 
   interface SidebarItem {
     id: string
@@ -286,7 +279,7 @@
           name: i.name,
           // Figma shows the same neutral foreground color for incomes and
           // expenses; the leading sign carries the direction.
-          value: `+${appStore.formatCurrencyCode(i.amount)} / ${frequencySuffix(i.frequency)}`,
+          value: `+${appStore.formatCurrencyCode(i.amount)} / ${getFrequencyShortLabel($_, i.frequency)}`,
           onClick: () => openEditDialog('income', i),
         })),
     },
@@ -299,7 +292,7 @@
         .map((e) => ({
           id: e.id,
           name: e.name,
-          value: `-${appStore.formatCurrencyCode(e.amount)} / ${frequencySuffix(e.frequency)}`,
+          value: `-${appStore.formatCurrencyCode(e.amount)} / ${getFrequencyShortLabel($_, e.frequency)}`,
           hasInsufficientFunds: failingExpenseIds.has(e.id),
           onClick: () => openEditDialog('expense', e),
         })),


### PR DESCRIPTION
Income and expense cards on the Financial data pages showed only the amount (e.g. `+3 000 Kč`), so monthly and yearly items were indistinguishable. The collapsed value now appends the localized frequency suffix per Figma: `/ m`, `/ y`, `/ w` (Czech: `/ m`, `/ r`, `/ t`).

The short labels already existed in both locale files, and the plan page had a private `frequencySuffix()` doing the same lookup — extracted it into a shared `getFrequencyShortLabel()` in `select-options.ts` and reused it in both places.

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)