### PR TITLE
fix: remove dead Advanced options switch from asset editors

### DIFF
--- a/src/lib/components/investments-editor.svelte
+++ b/src/lib/components/investments-editor.svelte
@@ -9,10 +9,8 @@
   import SuffixedInput from '$lib/components/suffixed-input.svelte'
   import { Button } from '$lib/components/ui/button'
   import { Label } from '$lib/components/ui/label'
-  import { Switch } from '$lib/components/ui/switch'
   import type { ProfileInvestment } from '$lib/schemas'
   import { appStore } from '$lib/stores/app.svelte'
-  import { notImplemented } from '$lib/utils'
 
   interface InvestmentUI {
     id: string
@@ -173,13 +171,6 @@
               }}
             />
           </div>
-        </div>
-
-        <div class="flex items-center gap-2">
-          <Switch checked={false} onCheckedChange={notImplemented} />
-          <span class="text-sm font-medium text-muted-foreground">
-            {$_('page.setup.common.advancedOptions')}
-          </span>
         </div>
       {/snippet}
     </EditableItemCard>

--- a/src/lib/components/liabilities-editor.svelte
+++ b/src/lib/components/liabilities-editor.svelte
@@ -10,11 +10,9 @@
   import SuffixedInput from '$lib/components/suffixed-input.svelte'
   import { Button } from '$lib/components/ui/button'
   import { Label } from '$lib/components/ui/label'
-  import { Switch } from '$lib/components/ui/switch'
   import type { Frequency, ProfileLiability } from '$lib/schemas'
   import { getFrequencyItems } from '$lib/select-options'
   import { appStore } from '$lib/stores/app.svelte'
-  import { notImplemented } from '$lib/utils'
 
   interface LiabilityUI {
     id: string
@@ -225,13 +223,6 @@
               }}
             />
           </div>
-        </div>
-
-        <div class="flex items-center gap-2">
-          <Switch checked={false} onCheckedChange={notImplemented} />
-          <span class="text-sm font-medium text-muted-foreground">
-            {$_('page.setup.common.advancedOptions')}
-          </span>
         </div>
       {/snippet}
     </EditableItemCard>

--- a/src/lib/components/tangible-assets-editor.svelte
+++ b/src/lib/components/tangible-assets-editor.svelte
@@ -10,11 +10,9 @@
   import SuffixedInput from '$lib/components/suffixed-input.svelte'
   import { Button } from '$lib/components/ui/button'
   import { Label } from '$lib/components/ui/label'
-  import { Switch } from '$lib/components/ui/switch'
   import type { Frequency, ProfileTangibleAsset, TangibleAssetStatus } from '$lib/schemas'
   import { getFrequencyItems, getTangibleAssetStatusItems } from '$lib/select-options'
   import { appStore } from '$lib/stores/app.svelte'
-  import { notImplemented } from '$lib/utils'
 
   interface AssetUI {
     id: string
@@ -267,13 +265,6 @@
             </div>
           </div>
         {/if}
-
-        <div class="flex items-center gap-2">
-          <Switch checked={false} onCheckedChange={notImplemented} />
-          <span class="text-sm font-medium text-muted-foreground">
-            {$_('page.setup.common.advancedOptions')}
-          </span>
-        </div>
       {/snippet}
     </EditableItemCard>
   {/each}


### PR DESCRIPTION
## Summary

The tangible-assets, investments, and liabilities editors each rendered an "Advanced options" switch that was a dead placeholder: hard-wired `checked={false}` with `notImplemented()` as its only handler, and no schema fields or UI behind it.

It misled users into thinking the financing fields (outstanding balance, installment frequency, annual rate, installment amount, remaining term) were locked behind it — those are actually gated by the Status dropdown (`status === 'financed'`) and remain fully functional.

## Changes

- Remove the switch block and now-unused `Switch`/`notImplemented` imports from `tangible-assets-editor.svelte`, `investments-editor.svelte`, and `liabilities-editor.svelte`
- `page.setup.common.advancedOptions` translation key kept — still used by the working advanced toggle in `cash-flow-item-card.svelte`

## Test plan

- `pnpm check:all` passes (format, lint, svelte-check, knip, check-locales)
- Manual: Financial data → Tangible assets — switch gone; Status = "Financed" still reveals the financing fields; same for Investments and Liabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)