### PR TITLE
fix: show zero liabilities as plain 0 instead of -0

### DIFF
--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -55,6 +55,17 @@ describe('cached formatters', () => {
   it('falls back for unsupported currency codes', () => {
     expect(formatCurrency(1000, 'NOTACURRENCY', 'en-US')).toBe('1,000 NOTACURRENCY')
   })
+
+  it('renders negative zero as plain 0 (e.g. a negated zero liabilities total)', () => {
+    expect(formatNumber(-0, 'en-US')).toBe('0')
+    expect(formatCurrency(-0, 'USD', 'en-US')).toBe('$0')
+    expect(formatCurrencyCode(-0, 'USD', 'en-US')).toBe('USD 0')
+    expect(formatCompactCurrency(-0, 'USD', 'en-US')).toBe('$0.0')
+  })
+
+  it('keeps the minus sign for real negative values', () => {
+    expect(formatCurrencyCode(-5000, 'USD', 'en-US')).toBe('-USD 5,000')
+  })
 })
 
 // These pass in every timezone; `new Date('YYYY-MM-DD')` (UTC parse) and

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -116,11 +116,16 @@ function getNumberFormat(
   return formatter
 }
 
+// -0 renders as "-0" in Intl.NumberFormat (e.g. a negated zero liabilities
+// total); money displays should show plain 0
+const unsignZero = (value: number) => (value === 0 ? 0 : value)
+
 export function formatNumber(value: number, locale?: string): string {
-  return getNumberFormat(locale, { maximumFractionDigits: 4 }).format(value)
+  return getNumberFormat(locale, { maximumFractionDigits: 4 }).format(unsignZero(value))
 }
 
 export function formatCurrency(value: number, currency: string, locale?: string): string {
+  value = unsignZero(value)
   try {
     return getNumberFormat(locale, {
       style: 'currency',
@@ -134,6 +139,7 @@ export function formatCurrency(value: number, currency: string, locale?: string)
 }
 
 export function formatCurrencyCode(value: number, currency: string, locale?: string): string {
+  value = unsignZero(value)
   try {
     return getNumberFormat(locale, {
       style: 'currency',
@@ -148,6 +154,7 @@ export function formatCurrencyCode(value: number, currency: string, locale?: str
 }
 
 export function formatCompactCurrency(value: number, currency: string, locale?: string): string {
+  value = unsignZero(value)
   try {
     return getNumberFormat(locale, {
       style: 'currency',

--- a/src/routes/(app)/financial-data/+page.svelte
+++ b/src/routes/(app)/financial-data/+page.svelte
@@ -80,7 +80,7 @@
     label={$_('page.financialData.nav.liabilities')}
     amount={appStore.formatCurrencyCode(-liabilities)}
     color={CATEGORY_COLORS.liabilities[0]}
-    negative
+    negative={liabilities > 0}
   />
   <Separator />
   <BreakdownRow

--- a/src/routes/(app)/financial-data/liabilities/+page.svelte
+++ b/src/routes/(app)/financial-data/liabilities/+page.svelte
@@ -6,7 +6,7 @@
   import LiabilitiesEditor from '$lib/components/liabilities-editor.svelte'
   import { getLiabilitiesTotal } from '$lib/financial-totals'
   import { appStore } from '$lib/stores/app.svelte'
-  import { formatLastUpdated } from '$lib/utils'
+  import { cn, formatLastUpdated } from '$lib/utils'
 
   const liabilities = $derived(appStore.profile.liabilities ?? [])
   const total = $derived(getLiabilitiesTotal(appStore.profile))
@@ -28,7 +28,7 @@
   <DonutChart {segments} size={160} variant="pie" />
   <div class="flex flex-1 flex-col items-start gap-2">
     <p class="text-lg leading-7 font-medium">{$_('page.financialData.liabilities.title')}</p>
-    <p class="text-3xl leading-9 font-bold text-destructive">
+    <p class={cn('text-3xl leading-9 font-bold', total > 0 && 'text-destructive')}>
       {appStore.formatCurrencyCode(-total)}
     </p>
     <span class="text-xs leading-4 text-muted-foreground">


### PR DESCRIPTION
## Summary

With no liabilities, the Financial data overview row and the Liabilities subpage total displayed "-0 EUR" in red. Negating a zero total produces JavaScript `-0`, which `Intl.NumberFormat` renders with a minus sign.

## Changes

- `src/lib/utils.ts`: normalize `-0` to `0` (`unsignZero`) in all four shared formatters (`formatNumber`, `formatCurrency`, `formatCurrencyCode`, `formatCompactCurrency`), so every display path — including the `appStore` wrappers — is covered
- Only apply the red `text-destructive` color to liability amounts when the total is actually positive (overview breakdown row + liabilities subpage total)
- The plan page already guarded both the sign and the color itself and was not affected

## Test plan

- New unit tests: `-0` renders unsigned across all formatters; real negatives keep their minus sign
- `pnpm test:unit` and `pnpm check:all` pass
- Verified in the app: zero-liability profile shows "EUR 0" in normal color; a profile with debt still shows "-EUR 192,000" in red

🤖 Generated with [Claude Code](https://claude.com/claude-code)