### PR TITLE
feat: edit item card names inline without a pencil toggle

### DIFF
--- a/src/lib/components/cash-flow-item-card.svelte
+++ b/src/lib/components/cash-flow-item-card.svelte
@@ -30,7 +30,6 @@
     change_over_time: ChangeOverTime
     change_percentage?: number
     editing: boolean
-    editingName: boolean
   }
 
   interface Props {
@@ -47,8 +46,6 @@
     onToggleEditing: () => void
     onDuplicate: () => void
     onDelete: () => void
-    onStartEditingName: () => void
-    onStopEditingName: () => void
     extraAdvancedContent?: Snippet
   }
 
@@ -66,8 +63,6 @@
     onToggleEditing,
     onDuplicate,
     onDelete,
-    onStartEditingName,
-    onStopEditingName,
     extraAdvancedContent,
   }: Props = $props()
 
@@ -88,8 +83,6 @@
   {onToggleEditing}
   {onDuplicate}
   {onDelete}
-  {onStartEditingName}
-  {onStopEditingName}
 >
   {#snippet expandedContent()}
     <!-- Amount and Frequency row -->

--- a/src/lib/components/editable-item-card.svelte
+++ b/src/lib/components/editable-item-card.svelte
@@ -5,7 +5,6 @@
   import ChevronsUpDown from '@lucide/svelte/icons/chevrons-up-down'
   import Copy from '@lucide/svelte/icons/copy'
   import EllipsisVertical from '@lucide/svelte/icons/ellipsis-vertical'
-  import SquarePen from '@lucide/svelte/icons/square-pen'
   import Trash2 from '@lucide/svelte/icons/trash-2'
 
   import { Button } from '$lib/components/ui/button'
@@ -15,7 +14,6 @@
 
   interface EditableItem {
     editing: boolean
-    editingName: boolean
     name: string
   }
 
@@ -27,8 +25,6 @@
     onToggleEditing: () => void
     onDuplicate: () => void
     onDelete: () => void
-    onStartEditingName: () => void
-    onStopEditingName: () => void
     expandedContent: Snippet
   }
 
@@ -40,10 +36,11 @@
     onToggleEditing,
     onDuplicate,
     onDelete,
-    onStartEditingName,
-    onStopEditingName,
     expandedContent,
   }: Props = $props()
+
+  // Snapshot for Escape-to-revert; edits commit live via oninput.
+  let nameBeforeEdit = ''
 </script>
 
 <Card class="gap-0 py-0">
@@ -58,26 +55,23 @@
           {#if dotColor}
             <div class="size-4 shrink-0 rounded-xs" style:background-color={dotColor}></div>
           {/if}
-          {#if item.editingName}
-            <Input
-              value={item.name}
-              oninput={(e) => {
-                item.name = (e.target as HTMLInputElement).value
-              }}
-              onblur={onStopEditingName}
-              onkeydown={(e) => {
-                if (e.key === 'Enter') onStopEditingName()
-              }}
-              class="flex-1"
-            />
-          {:else}
-            <span class="flex-1 truncate text-base font-medium">
-              {item.name}
-            </span>
-            <Button variant="ghost" size="icon" onclick={onStartEditingName}>
-              <SquarePen class="size-4" />
-            </Button>
-          {/if}
+          <Input
+            value={item.name}
+            oninput={(e) => {
+              item.name = (e.target as HTMLInputElement).value
+            }}
+            onfocus={() => {
+              nameBeforeEdit = item.name
+            }}
+            onkeydown={(e) => {
+              if (e.key === 'Enter') (e.target as HTMLInputElement).blur()
+              if (e.key === 'Escape') {
+                item.name = nameBeforeEdit
+                ;(e.target as HTMLInputElement).blur()
+              }
+            }}
+            class="flex-1"
+          />
           <DropdownMenu.Root>
             <DropdownMenu.Trigger>
               {#snippet child({ props })}

--- a/src/lib/components/expenses-editor.svelte
+++ b/src/lib/components/expenses-editor.svelte
@@ -14,7 +14,6 @@
     amount: number | undefined
     showAdvanced: boolean
     editing: boolean
-    editingName: boolean
   }
 
   interface Props {
@@ -37,7 +36,6 @@
       amount: exp.amount > 0 ? exp.amount : undefined,
       showAdvanced: false,
       editing: false,
-      editingName: false,
     }))
   }
 
@@ -71,7 +69,6 @@
       change_over_time: 'none',
       change_percentage: undefined,
       editing: true,
-      editingName: false,
     })
   }
 
@@ -83,7 +80,6 @@
       id: crypto.randomUUID(),
       name: $_('page.setup.common.copySuffix', { values: { name: expense.name } }),
       editing: true,
-      editingName: false,
     })
   }
 
@@ -166,12 +162,6 @@
       }}
       onDuplicate={() => duplicateExpense(expense)}
       onDelete={() => deleteExpense(expense)}
-      onStartEditingName={() => {
-        expense.editingName = true
-      }}
-      onStopEditingName={() => {
-        expense.editingName = false
-      }}
     />
   {/each}
 

--- a/src/lib/components/incomes-editor.svelte
+++ b/src/lib/components/incomes-editor.svelte
@@ -17,7 +17,6 @@
     amount: number | undefined
     showAdvanced: boolean
     editing: boolean
-    editingName: boolean
   }
 
   interface Props {
@@ -40,7 +39,6 @@
       amount: inc.amount > 0 ? inc.amount : undefined,
       showAdvanced: false,
       editing: false,
-      editingName: false,
     }))
   }
 
@@ -78,7 +76,6 @@
       change_over_time: 'none',
       change_percentage: undefined,
       editing: true,
-      editingName: false,
     })
   }
 
@@ -90,7 +87,6 @@
       id: crypto.randomUUID(),
       name: $_('page.setup.common.copySuffix', { values: { name: income.name } }),
       editing: true,
-      editingName: false,
     })
   }
 
@@ -173,12 +169,6 @@
       }}
       onDuplicate={() => duplicateIncome(income)}
       onDelete={() => deleteIncome(income)}
-      onStartEditingName={() => {
-        income.editingName = true
-      }}
-      onStopEditingName={() => {
-        income.editingName = false
-      }}
     >
       {#snippet extraAdvancedContent()}
         <div class="flex items-end gap-4">

--- a/src/lib/components/investments-editor.svelte
+++ b/src/lib/components/investments-editor.svelte
@@ -20,7 +20,6 @@
     balance: number | undefined
     apy: number | undefined
     editing: boolean
-    editingName: boolean
   }
 
   interface Props {
@@ -36,7 +35,6 @@
       balance: inv.balance > 0 ? inv.balance : undefined,
       apy: inv.apy > 0 ? inv.apy : undefined,
       editing: false,
-      editingName: false,
     }))
   }
 
@@ -61,7 +59,6 @@
       balance: undefined,
       apy: undefined,
       editing: true,
-      editingName: false,
     })
   }
 
@@ -73,7 +70,6 @@
       id: crypto.randomUUID(),
       name: $_('page.setup.common.copySuffix', { values: { name: investment.name } }),
       editing: true,
-      editingName: false,
     })
   }
 
@@ -142,12 +138,6 @@
       }}
       onDuplicate={() => duplicateInvestment(investment)}
       onDelete={() => deleteInvestment(investment)}
-      onStartEditingName={() => {
-        investment.editingName = true
-      }}
-      onStopEditingName={() => {
-        investment.editingName = false
-      }}
     >
       {#snippet expandedContent()}
         <div class="flex items-center gap-2">

--- a/src/lib/components/liabilities-editor.svelte
+++ b/src/lib/components/liabilities-editor.svelte
@@ -25,7 +25,6 @@
     installment_amount: number | undefined
     remaining_term: number | undefined
     editing: boolean
-    editingName: boolean
   }
 
   interface Props {
@@ -44,7 +43,6 @@
       installment_amount: l.installment_amount > 0 ? l.installment_amount : undefined,
       remaining_term: l.remaining_term > 0 ? l.remaining_term : undefined,
       editing: false,
-      editingName: false,
     }))
   }
 
@@ -74,7 +72,6 @@
       installment_amount: undefined,
       remaining_term: undefined,
       editing: true,
-      editingName: false,
     })
   }
 
@@ -86,7 +83,6 @@
       id: crypto.randomUUID(),
       name: $_('page.setup.common.copySuffix', { values: { name: liability.name } }),
       editing: true,
-      editingName: false,
     })
   }
 
@@ -158,12 +154,6 @@
       }}
       onDuplicate={() => duplicateLiability(liability)}
       onDelete={() => deleteLiability(liability)}
-      onStartEditingName={() => {
-        liability.editingName = true
-      }}
-      onStopEditingName={() => {
-        liability.editingName = false
-      }}
     >
       {#snippet expandedContent()}
         <div class="flex flex-col gap-2">

--- a/src/lib/components/tangible-assets-editor.svelte
+++ b/src/lib/components/tangible-assets-editor.svelte
@@ -27,7 +27,6 @@
     installment_amount: number | undefined
     remaining_term: number | undefined
     editing: boolean
-    editingName: boolean
   }
 
   interface Props {
@@ -55,7 +54,6 @@
       remaining_term:
         a.remaining_term !== undefined && a.remaining_term > 0 ? a.remaining_term : undefined,
       editing: false,
-      editingName: false,
     }))
   }
 
@@ -89,7 +87,6 @@
       installment_amount: undefined,
       remaining_term: undefined,
       editing: true,
-      editingName: false,
     })
   }
 
@@ -101,7 +98,6 @@
       id: crypto.randomUUID(),
       name: $_('page.setup.common.copySuffix', { values: { name: asset.name } }),
       editing: true,
-      editingName: false,
     })
   }
 
@@ -175,12 +171,6 @@
       }}
       onDuplicate={() => duplicateAsset(asset)}
       onDelete={() => deleteAsset(asset)}
-      onStartEditingName={() => {
-        asset.editingName = true
-      }}
-      onStopEditingName={() => {
-        asset.editingName = false
-      }}
     >
       {#snippet expandedContent()}
         <div class="flex items-center gap-2">


### PR DESCRIPTION
## Summary

Renaming an item card previously required pressing a pencil button that swapped the name for an **unfocused** input — which then couldn't be dismissed without clicking into it first and clicking away again.

Now, when a card is expanded, the name is always an inline input:

- Click the name to edit; changes commit live (picked up by the editors' debounced auto-save)
- **Enter** or click-away finishes editing
- **Escape** reverts to the name as it was when the field was focused

## Changes

- `editable-item-card.svelte`: always render the name `Input` in the expanded header; add Escape-to-revert; remove the pencil button and `editingName` branch
- `cash-flow-item-card.svelte` + the five editors (investments, tangible-assets, liabilities, incomes, expenses): remove the now-dead `editingName` state and `onStartEditingName`/`onStopEditingName` callbacks (net −63 lines)
- Plan-page dialogs keep their separate dialog-title edit pattern (possible follow-up)

## Test plan

- `pnpm check:all` passes
- Verified in the app: expanded investment card shows the name as an input; rename + Enter persists across reload; typing + Escape reverts and blurs; collapsed cards still render the plain-text name row

🤖 Generated with [Claude Code](https://claude.com/claude-code)