### PR TITLE
feat: confirm before deleting an item from the card menu

### DIFF
--- a/src/lib/components/editable-item-card.svelte
+++ b/src/lib/components/editable-item-card.svelte
@@ -92,7 +92,18 @@
                 {$_('page.setup.common.duplicate')}
               </DropdownMenu.Item>
               <DropdownMenu.Separator />
-              <DropdownMenu.Item class="text-destructive" onclick={onDelete}>
+              <DropdownMenu.Item
+                class="text-destructive"
+                onclick={() => {
+                  if (
+                    window.confirm(
+                      $_('page.setup.common.deleteConfirm', { values: { name: item.name } }),
+                    )
+                  ) {
+                    onDelete()
+                  }
+                }}
+              >
                 <Trash2 class="size-4" />
                 {$_('page.setup.common.delete')}
               </DropdownMenu.Item>

--- a/src/lib/locales/cs.json
+++ b/src/lib/locales/cs.json
@@ -263,6 +263,7 @@
         "amount": "Částka",
         "frequency": "Frekvence",
         "advancedOptions": "Pokročilé možnosti",
+        "deleteConfirm": "Smazat „{name}“? Akci nelze vrátit zpět.",
         "start": "Začátek",
         "end": "Konec",
         "changeOverTime": "Změna v čase",

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -263,6 +263,7 @@
         "amount": "Amount",
         "frequency": "Frequency",
         "advancedOptions": "Advanced options",
+        "deleteConfirm": "Delete \"{name}\"? This cannot be undone.",
         "start": "Start",
         "end": "End",
         "changeOverTime": "Change over time",


### PR DESCRIPTION
## Summary

The item cards' ⋮ menu deleted immediately with no confirmation — and with debounced auto-save, the deletion persisted right away. The Delete menu item now asks for confirmation first, using the same `window.confirm` pattern the plan-page dialogs already use, with the item's name in the message (`Delete "Crypto fund"? This cannot be undone.`).

One change in the shared `editable-item-card.svelte` covers all five financial editors (investments, tangible assets, liabilities, incomes, expenses).

## Changes

- `editable-item-card.svelte`: wrap the Delete menu item's `onDelete()` in `window.confirm`
- Locales: new `page.setup.common.deleteConfirm` key in `en.json` and `cs.json` with `{name}` interpolation

## Test plan

- `pnpm check:all` passes
- Verified in the app: ⋮ → Delete shows the confirm naming the item; Cancel keeps it; OK deletes it and the deletion persists after reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)