### PR TITLE
chore: serve production at kalkul.app instead of next.kalkul.app

### DIFF
--- a/.github/workflows/deploy-dev-preview.yaml
+++ b/.github/workflows/deploy-dev-preview.yaml
@@ -13,8 +13,6 @@ concurrency: preview-${{ github.ref }}
 permissions:
   contents: write
   pull-requests: write
-  pages: write
-  id-token: write
 
 jobs:
   deploy-preview:

--- a/.github/workflows/deploy-dev-preview.yaml
+++ b/.github/workflows/deploy-dev-preview.yaml
@@ -48,4 +48,4 @@ jobs:
         with:
           source-dir: ./build
           umbrella-dir: /
-          pages-base-url: next.kalkul.app
+          pages-base-url: kalkul.app

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -1,4 +1,4 @@
-name: Deploy to GitHub Pages
+name: Deploy production
 
 on:
   push:
@@ -37,7 +37,10 @@ jobs:
       - name: Copy SPA fallback
         run: cp build/index.html build/404.html
 
-      - name: Deploy to GitHub Pages
+      # Publish the production build to the root of the gh-pages branch, which
+      # the DigitalOcean App Platform static site serves at kalkul.app. The
+      # per-PR preview directories (pr-*) are left untouched.
+      - name: Deploy to gh-pages root
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: build

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -38,8 +38,8 @@ jobs:
         run: cp build/index.html build/404.html
 
       # Publish the production build to the root of the gh-pages branch, which
-      # the DigitalOcean App Platform static site serves at kalkul.app. The
-      # per-PR preview directories (pr-*) are left untouched.
+      # GitHub Pages serves at kalkul.app. The per-PR preview directories
+      # (pr-*) are left untouched.
       - name: Deploy to gh-pages root
         uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,7 +177,7 @@ When linking from a bare `<a>` tag (not the `Button` component), the `svelte/no-
 ### Deployment Context
 
 - The app is deployed as a static SPA everywhere (production and PR previews)
-- Production is hosted at `kalkul.app` — a DigitalOcean App Platform static site serving the `gh-pages` branch
+- Production is hosted on GitHub Pages at `kalkul.app` (served from the `gh-pages` branch)
 - Data is stored locally in the browser via localStorage
 - Environment variables control routing and base URL
 - See README.md for deployment details

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,7 +177,7 @@ When linking from a bare `<a>` tag (not the `Button` component), the `svelte/no-
 ### Deployment Context
 
 - The app is deployed as a static SPA everywhere (production and PR previews)
-- Production is hosted on GitHub Pages at `next.kalkul.app`
+- Production is hosted at `kalkul.app` — a DigitalOcean App Platform static site serving the `gh-pages` branch
 - Data is stored locally in the browser via localStorage
 - Environment variables control routing and base URL
 - See README.md for deployment details

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ pnpm test:integration # Run e2e tests (Playwright)
 - `kalkul.app/pr-{num}` - PR previews (Static SPA)
 
 Both production and PR previews are published to the `gh-pages` branch — `main` deploys to the
-root, each open PR deploys to its own `pr-{num}/` subdirectory. A DigitalOcean App Platform
-static site serves that branch at `kalkul.app`.
+root, each open PR deploys to its own `pr-{num}/` subdirectory. GitHub Pages serves that branch
+at `kalkul.app`.
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,12 @@ pnpm test:integration # Run e2e tests (Playwright)
 
 ## Deployments
 
-- [`next.kalkul.app`](https://next.kalkul.app) - Production (Static SPA on GitHub Pages)
-- `next.kalkul.app/pr-{num}` - PR previews (Static SPA)
+- [`kalkul.app`](https://kalkul.app) - Production (Static SPA)
+- `kalkul.app/pr-{num}` - PR previews (Static SPA)
+
+Both production and PR previews are published to the `gh-pages` branch — `main` deploys to the
+root, each open PR deploys to its own `pr-{num}/` subdirectory. A DigitalOcean App Platform
+static site serves that branch at `kalkul.app`.
 
 ## Environment Variables
 


### PR DESCRIPTION
## Summary

Production cutover: **kalkul.app** is served from this repo (GitHub Pages) instead of the legacy [snaha/kalkul-legacy](https://github.com/snaha/kalkul-legacy) repo's DigitalOcean app.

> **Note**: repos were renamed as part of this cutover — the old `snaha/kalkul` is now `snaha/kalkul-legacy`, and this repo (formerly `snaha/kalkul-next`) is now `snaha/kalkul`.

The GitHub Pages custom domain moved from `next.kalkul.app` to `kalkul.app`. The deploy mechanism is unchanged: `main` → `gh-pages` root, PR previews → `pr-{num}/` subdirectories, all served by Pages at the new domain. The DigitalOcean app is retired.

## Changes

- `deploy-dev-preview.yaml`: PR preview links point at `kalkul.app/pr-{num}` (was `next.kalkul.app/pr-{num}`)
- `deploy-prod.yaml`: workflow renamed to "Deploy production", comments updated
- `README.md` / `AGENTS.md`: deployment docs updated

## Cutover sequence (outside this PR)

1. ✅ Rename `snaha/kalkul` → `snaha/kalkul-legacy`, then `snaha/kalkul-next` → `snaha/kalkul`
2. ✅ GitHub Pages custom domain: `next.kalkul.app` → `kalkul.app`
3. Cloudflare DNS: `kalkul.app` apex → `snaha.github.io` (DNS-only until cert issued)
4. Verify kalkul.app serves the new app, HTTPS enforced
5. Merge this PR
6. Delete the DO app; remove `next.`/`preview.`/`dev.kalkul.app` DNS records
7. Archive `snaha/kalkul-legacy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)