### PR TITLE
fix: parse plan and birth years timezone-safely on the plan page

### DIFF
--- a/src/lib/plan-projection.ts
+++ b/src/lib/plan-projection.ts
@@ -359,15 +359,23 @@ export function filterById<T extends { id: string }>(
   return items.filter((item) => set.has(item.id))
 }
 
+/**
+ * Year of a date-only ISO string (`YYYY-MM-DD`), parsed directly from the
+ * string. ISO date-only strings parse as UTC, so `new Date(...).getFullYear()`
+ * shifts first-of-year dates back a year in UTC-negative timezones — every
+ * consumer of plan/birth dates must use this instead.
+ */
+export function yearOf(dateString: string): number {
+  return Number(dateString.slice(0, 4))
+}
+
 export function getYearlyPlanProjection(plan: Portfolio, profile: Profile): YearlyProjection[] {
-  // Direct string parse: ISO date-only strings parse as UTC, so
-  // `new Date(...).getFullYear()` is timezone-dependent.
-  const startYear = Number(plan.start_date.slice(0, 4))
-  const endYear = Number(plan.end_date.slice(0, 4))
+  const startYear = yearOf(plan.start_date)
+  const endYear = yearOf(plan.end_date)
 
   if (endYear < startYear) return []
 
-  const birthYear = profile.birth_date ? Number(profile.birth_date.slice(0, 4)) : undefined
+  const birthYear = profile.birth_date ? yearOf(profile.birth_date) : undefined
 
   const investments: ProfileInvestment[] = filterById(
     profile.investments,

--- a/src/routes/(app)/plan/[id]/+page.svelte
+++ b/src/routes/(app)/plan/[id]/+page.svelte
@@ -30,7 +30,7 @@
   import { Input } from '$lib/components/ui/input'
   import { Separator } from '$lib/components/ui/separator'
   import { Slider } from '$lib/components/ui/slider'
-  import { getYearlyPlanProjection } from '$lib/plan-projection'
+  import { getYearlyPlanProjection, yearOf } from '$lib/plan-projection'
   import routes from '$lib/routes'
   import type {
     Expense,
@@ -55,11 +55,10 @@
   const planId = $derived(page.params.id)
   const plan = $derived(appStore.portfolios.find((p) => p.id === planId))
 
-  // Year range from portfolio dates
-  const startYear = $derived(
-    plan ? new Date(plan.start_date).getFullYear() : new Date().getFullYear(),
-  )
-  const endYear = $derived(plan ? new Date(plan.end_date).getFullYear() : new Date().getFullYear())
+  // Year range from portfolio dates (yearOf: date-only strings parse as UTC,
+  // so new Date(...).getFullYear() would be off by one in UTC-negative zones)
+  const startYear = $derived(plan ? yearOf(plan.start_date) : new Date().getFullYear())
+  const endYear = $derived(plan ? yearOf(plan.end_date) : new Date().getFullYear())
 
   // State for UI
   let activeTab = $state<'cashflows' | 'assets'>('cashflows')


### PR DESCRIPTION
The plan page derived startYear/endYear via new Date(...).getFullYear(),
which is off by one for first-of-year date strings in UTC-negative
timezones (the slider could not reach the plan's final year and could
select a year with no projection entry). Export the projection engine's
string-parse convention as yearOf() and use it on the page.

Closes #113



Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)
