### PR TITLE
fix: floor effective investment APY at -100% as the comment promises

### DIFF
--- a/src/lib/plan-projection.test.ts
+++ b/src/lib/plan-projection.test.ts
@@ -1658,6 +1658,28 @@ describe('getYearlyPlanProjection', () => {
     expect(result[1].investments).toBeCloseTo(1060, 6)
   })
 
+  it('floors the effective APY at −100 % so extreme fees decay the balance to 0', () => {
+    // TER + ongoing fee = 250 % ≫ 100 + APY: without the floor the yearly
+    // multiplier would be 1 + (5 − 250)/100 = −1.45 and the balance would
+    // oscillate in sign; with it the multiplier is 0.
+    const investments: ProfileInvestment[] = [
+      {
+        id: 'i1',
+        name: 'Fund',
+        balance: 1000,
+        apy: 5,
+        ter: 200,
+        entry_fee: 50,
+        entry_fee_type: 'ongoing',
+      },
+    ]
+    const result = getYearlyPlanProjection(makePlan(), makeProfile({ investments }))
+    expect(result[0].investments).toBeCloseTo(1000, 6)
+    for (const entry of result.slice(1)) {
+      expect(entry.investments).toBe(0)
+    }
+  })
+
   it('splits a forty-sixty entry fee 40% upfront + 60% ongoing drag', () => {
     const investments: ProfileInvestment[] = [
       {

--- a/src/lib/plan-projection.ts
+++ b/src/lib/plan-projection.ts
@@ -76,6 +76,9 @@ const INSTALLMENT_PERIODS_PER_YEAR: Record<Frequency, number> = {
   yearly: 1,
 }
 
+// Floor for the effective investment APY: −100% is a total loss.
+const DECIMAL_MINUS_100 = new Decimal(-100)
+
 function resolveStartYear(
   cashFlow: CashFlowTemporal,
   planStartYear: number,
@@ -408,9 +411,10 @@ export function getYearlyPlanProjection(plan: Portfolio, profile: Profile): Year
   const investmentsById = new Map<string, ProfileInvestment>(investments.map((i) => [i.id, i]))
   // Effective APY = APY − TER − ongoing portion of the entry fee. The ongoing
   // entry-fee component models the year-after-year drag (whole fee for
-  // 'ongoing', 60% for 'forty-sixty', 0 for 'upfront'). Capped at zero so a
-  // misconfigured fee can't flip compounding into negative growth via the
-  // multiplier (>100% loss/yr).
+  // 'ongoing', 60% for 'forty-sixty', 0 for 'upfront'). Floored at −100% (a
+  // total loss) so the yearly multiplier bottoms out at 0 — fees exceeding
+  // 100 + APY would otherwise flip the multiplier negative and make the
+  // balance oscillate in sign.
   const investmentApy = new Map<string, Decimal>(
     investments.map((i) => {
       const apy = new Decimal(i.apy)
@@ -419,7 +423,7 @@ export function getYearlyPlanProjection(plan: Portfolio, profile: Profile): Year
       let ongoingDrag = DECIMAL_0
       if (i.entry_fee_type === 'ongoing') ongoingDrag = entryFee
       else if (i.entry_fee_type === 'forty-sixty') ongoingDrag = entryFee.mul(0.6)
-      return [i.id, apy.minus(ter).minus(ongoingDrag)]
+      return [i.id, Decimal.max(apy.minus(ter).minus(ongoingDrag), DECIMAL_MINUS_100)]
     }),
   )
 


### PR DESCRIPTION
TER + ongoing entry fee exceeding 100 + APY flipped the yearly
multiplier negative, making balances oscillate in sign. The doc comment
promised a cap that was never implemented; the schema does not bound
fee inputs, so this was reachable with user-entered values. Floor the
effective APY at -100% (total loss) so the multiplier bottoms out at 0,
and lock it with a monotonic-decay regression test.

Closes #114

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)