### PR TITLE
fix: disable SSR so dev matches the client-only production build

### DIFF
--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -8,6 +8,14 @@ import { appStore } from '$lib/stores/app.svelte'
 
 import type { LayoutLoad } from './$types'
 
+// The app ships as a pure client-rendered SPA (adapter-static with an
+// index.html fallback and no prerendered routes), so production never runs
+// server-side. Dev SSR would, though — and it executes browser-only code on
+// Node (localStorage in the stores, the editors' onDestroy save flush, which
+// is the one lifecycle hook Svelte also runs during SSR). Declaring the app
+// client-only keeps dev behavior identical to production.
+export const ssr = false
+
 export const load: LayoutLoad = async () => {
   // Read localStorage synchronously here (before any component renders) so the
   // store is populated when route components evaluate their $state initializers.


### PR DESCRIPTION
Production deploys via adapter-static with an index.html fallback and
no prerendered routes, so nothing ever runs server-side. The dev server
still SSR'd first-page loads, executing browser-only code on Node: the
editors' onDestroy save flush hit localStorage and logged a
ReferenceError (and set the storage error store) on every editor page
render.

Closes #172



Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)
