### PR TITLE
fix: compare route ids instead of pathnames for step progress and nav highlighting

### DIFF
--- a/src/lib/components/financial-data-sidebar.svelte
+++ b/src/lib/components/financial-data-sidebar.svelte
@@ -4,8 +4,8 @@
   import { page } from '$app/state'
 
   import { Card } from '$lib/components/ui/card'
-  import { resolveFinancialDataRoute } from '$lib/financial-data-nav'
-  import routes from '$lib/routes'
+  import { type FinancialDataRoute, resolveFinancialDataRoute } from '$lib/financial-data-nav'
+  import routes, { routeFromId } from '$lib/routes'
   import { cn } from '$lib/utils'
 
   interface Props {
@@ -15,55 +15,38 @@
 
   let { variant = 'sidebar', class: className }: Props = $props()
 
-  const items: { href: string; label: string }[] = $derived([
+  const items: { route: FinancialDataRoute; label: string }[] = $derived([
+    { route: routes.FINANCIAL_DATA, label: $_('page.financialData.nav.overview') },
+    { route: routes.FINANCIAL_DATA_CASH, label: $_('page.financialData.nav.cash') },
+    { route: routes.FINANCIAL_DATA_INVESTMENTS, label: $_('page.financialData.nav.investments') },
     {
-      href: resolveFinancialDataRoute(routes.FINANCIAL_DATA),
-      label: $_('page.financialData.nav.overview'),
-    },
-    {
-      href: resolveFinancialDataRoute(routes.FINANCIAL_DATA_CASH),
-      label: $_('page.financialData.nav.cash'),
-    },
-    {
-      href: resolveFinancialDataRoute(routes.FINANCIAL_DATA_INVESTMENTS),
-      label: $_('page.financialData.nav.investments'),
-    },
-    {
-      href: resolveFinancialDataRoute(routes.FINANCIAL_DATA_TANGIBLE_ASSETS),
+      route: routes.FINANCIAL_DATA_TANGIBLE_ASSETS,
       label: $_('page.financialData.nav.tangibleAssets'),
     },
-    {
-      href: resolveFinancialDataRoute(routes.FINANCIAL_DATA_LIABILITIES),
-      label: $_('page.financialData.nav.liabilities'),
-    },
-    {
-      href: resolveFinancialDataRoute(routes.FINANCIAL_DATA_INCOMES),
-      label: $_('page.financialData.nav.incomes'),
-    },
-    {
-      href: resolveFinancialDataRoute(routes.FINANCIAL_DATA_EXPENSES),
-      label: $_('page.financialData.nav.expenses'),
-    },
+    { route: routes.FINANCIAL_DATA_LIABILITIES, label: $_('page.financialData.nav.liabilities') },
+    { route: routes.FINANCIAL_DATA_INCOMES, label: $_('page.financialData.nav.incomes') },
+    { route: routes.FINANCIAL_DATA_EXPENSES, label: $_('page.financialData.nav.expenses') },
   ])
 
-  const activePath = $derived(page.url.pathname.replace(/\/$/, ''))
+  // Compare route ids, not pathnames: the pathname carries the base path and
+  // stays constant under the hash router, so it never matches the constants.
+  const activeRoute = $derived(routeFromId(page.route.id))
   const cardWidth = $derived(variant === 'sidebar' ? 'w-72' : '')
   const itemHeight = $derived(variant === 'sidebar' ? 'h-8' : 'h-10')
-
-  function isActive(href: string): boolean {
-    return activePath === href.replace(/\/$/, '')
-  }
 </script>
 
 <Card class={cn('gap-0 p-2', cardWidth, className)}>
   <nav class="flex flex-col">
-    {#each items as item (item.href)}
+    {#each items as item (item.route)}
       <a
-        href={/* eslint-disable-line svelte/no-navigation-without-resolve */ item.href}
+        href={/* eslint-disable-line svelte/no-navigation-without-resolve */ resolveFinancialDataRoute(
+          item.route,
+        )}
         class={cn(
           'flex items-center gap-2 rounded-md p-2 text-sm leading-none transition-colors hover:bg-accent',
           itemHeight,
-          isActive(item.href) && 'bg-sidebar-accent font-medium text-sidebar-accent-foreground',
+          activeRoute === item.route &&
+            'bg-sidebar-accent font-medium text-sidebar-accent-foreground',
         )}
       >
         {item.label}

--- a/src/lib/routes.test.ts
+++ b/src/lib/routes.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import routes, { routeFromId } from './routes'
+
+describe('routeFromId', () => {
+  it('drops layout-group segments so ids match route constants', () => {
+    expect(routeFromId('/(app)/financial-data/cash')).toBe(routes.FINANCIAL_DATA_CASH)
+    expect(routeFromId('/(onboarding)/profile')).toBe(routes.PROFILE)
+    expect(routeFromId('/(onboarding)/finances/edit/investments')).toBe(
+      routes.FINANCES_EDIT_INVESTMENTS,
+    )
+    expect(routeFromId('/(add-plan)/plan/add/details')).toBe(routes.PLAN_ADD_DETAILS)
+  })
+
+  it('maps a group-only id to the root route', () => {
+    expect(routeFromId('/(app)')).toBe(routes.HOME)
+  })
+
+  it('keeps dynamic segments intact', () => {
+    expect(routeFromId('/(app)/plan/[id]')).toBe('/plan/[id]')
+  })
+
+  it('returns an empty string for a missing route id', () => {
+    expect(routeFromId(undefined)).toBe('')
+  })
+})

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -20,3 +20,17 @@ export default {
   PLAN_VIEW: '/plan',
   DEV: '/dev',
 } as const
+
+/**
+ * Convert a SvelteKit route id (e.g. `/(app)/financial-data/cash`) into the
+ * matching route constant path (`/financial-data/cash`) by dropping
+ * layout-group segments. Unlike `page.url.pathname`, the route id is
+ * unaffected by the configured base path and by the hash router used on PR
+ * previews, so comparisons against the constants above work on every
+ * deployment target.
+ */
+export function routeFromId(routeId: string | null | undefined): string {
+  if (!routeId) return ''
+  const path = routeId.replaceAll(/\/\([^)]+\)/g, '')
+  return path === '' ? '/' : path
+}

--- a/src/routes/(add-plan)/+layout.svelte
+++ b/src/routes/(add-plan)/+layout.svelte
@@ -10,7 +10,7 @@
   import ThemeSwitcher from '$lib/components/theme-switcher.svelte'
   import { Button } from '$lib/components/ui/button'
   import { Progress } from '$lib/components/ui/progress'
-  import routes from '$lib/routes'
+  import routes, { routeFromId } from '$lib/routes'
   import { appStore } from '$lib/stores/app.svelte'
 
   let { children } = $props()
@@ -19,8 +19,8 @@
   const totalSteps = $derived(steps.length)
 
   let currentStepIndex = $derived.by(() => {
-    const pathname = page.url.pathname.replace(/\/$/, '')
-    const idx = steps.findIndex((s) => pathname === s)
+    const current = routeFromId(page.route.id)
+    const idx = steps.findIndex((s) => current === s)
     return Math.max(0, idx)
   })
 

--- a/src/routes/(onboarding)/+layout.svelte
+++ b/src/routes/(onboarding)/+layout.svelte
@@ -10,7 +10,7 @@
   import { Button } from '$lib/components/ui/button'
   import { Progress } from '$lib/components/ui/progress'
   import { getOnboardingSteps } from '$lib/onboarding-steps'
-  import routes from '$lib/routes'
+  import routes, { routeFromId } from '$lib/routes'
   import { appStore } from '$lib/stores/app.svelte'
 
   let { children } = $props()
@@ -19,8 +19,8 @@
   const totalSteps = $derived(steps.length)
 
   let currentStepIndex = $derived.by(() => {
-    const pathname = page.url.pathname.replace(/\/$/, '')
-    const idx = steps.findIndex((s) => pathname === s)
+    const current = routeFromId(page.route.id)
+    const idx = steps.findIndex((s) => current === s)
     return Math.max(0, idx)
   })
 


### PR DESCRIPTION
PR previews deploy with the hash router (and a base path), where
page.url.pathname never matches raw route constants: the onboarding and
add-plan progress bars stuck at step one and no financial-data nav item
ever highlighted. Derive the current route from page.route.id via a new
routeFromId() helper (drops layout-group segments), which is base- and
router-agnostic.

Closes #117



Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)
