### PR TITLE
fix: make localStorage persistence safe end to end (banner, write validation, quarantine + salvage, tests)

### DIFF
--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -1,0 +1,20 @@
+import { appStore } from '$lib/stores/app.svelte'
+
+/**
+ * Serialize the current data via `appStore.exportBackup()` and trigger a
+ * browser download of the backup file. Shared by the navbar's export action
+ * and the storage-error banner.
+ */
+export function downloadBackup(): void {
+  const json = appStore.exportBackup()
+  const blob = new Blob([json], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `kalkul-backup-${new Date().toISOString().slice(0, 10)}.json`
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  // Delay revoke so the browser has time to start the download.
+  setTimeout(() => URL.revokeObjectURL(url), 1000)
+}

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -1,20 +1,27 @@
 import { appStore } from '$lib/stores/app.svelte'
 
+/** Trigger a browser download of `text` as a JSON file named `filename`. */
+export function downloadTextAsFile(filename: string, text: string): void {
+  const blob = new Blob([text], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  // Delay revoke so the browser has time to start the download.
+  setTimeout(() => URL.revokeObjectURL(url), 1000)
+}
+
 /**
  * Serialize the current data via `appStore.exportBackup()` and trigger a
  * browser download of the backup file. Shared by the navbar's export action
  * and the storage-error banner.
  */
 export function downloadBackup(): void {
-  const json = appStore.exportBackup()
-  const blob = new Blob([json], { type: 'application/json' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = `kalkul-backup-${new Date().toISOString().slice(0, 10)}.json`
-  document.body.appendChild(a)
-  a.click()
-  document.body.removeChild(a)
-  // Delay revoke so the browser has time to start the download.
-  setTimeout(() => URL.revokeObjectURL(url), 1000)
+  downloadTextAsFile(
+    `kalkul-backup-${new Date().toISOString().slice(0, 10)}.json`,
+    appStore.exportBackup(),
+  )
 }

--- a/src/lib/components/navbar.svelte
+++ b/src/lib/components/navbar.svelte
@@ -8,6 +8,7 @@
   import { resolve } from '$app/paths'
 
   import logo from '$lib/assets/logo.svg'
+  import { downloadBackup } from '$lib/backup'
   import DiscordIcon from '$lib/components/icons/discord-icon.svelte'
   import GithubIcon from '$lib/components/icons/github-icon.svelte'
   import ThemeSwitcher from '$lib/components/theme-switcher.svelte'
@@ -31,26 +32,12 @@
     if (!importOpen) backupExported = false
   })
 
-  function exportData(): void {
-    const json = appStore.exportBackup()
-    const blob = new Blob([json], { type: 'application/json' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `kalkul-backup-${new Date().toISOString().slice(0, 10)}.json`
-    document.body.appendChild(a)
-    a.click()
-    document.body.removeChild(a)
-    // Delay revoke so the browser has time to start the download.
-    setTimeout(() => URL.revokeObjectURL(url), 1000)
-  }
-
   function triggerFileSelect(): void {
     fileInput?.click()
   }
 
   function exportBeforeImporting(): void {
-    exportData()
+    downloadBackup()
     // Keep the dialog open and transition to the "ready to import" state.
     // The file picker needs its own user gesture, so we don't open it here.
     backupExported = true
@@ -95,7 +82,7 @@
       <DropdownMenu.Content align="end">
         <DropdownMenu.Group>
           {#if hasData}
-            <DropdownMenu.Item onSelect={exportData}>
+            <DropdownMenu.Item onSelect={downloadBackup}>
               {$_('navbar.menu.exportData')}
             </DropdownMenu.Item>
           {/if}

--- a/src/lib/components/storage-error-banner.svelte
+++ b/src/lib/components/storage-error-banner.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import { _ } from 'svelte-i18n'
+
+  import FileDown from '@lucide/svelte/icons/file-down'
+  import TriangleAlert from '@lucide/svelte/icons/triangle-alert'
+
+  import { downloadBackup } from '$lib/backup'
+  import * as Alert from '$lib/components/ui/alert'
+  import { Button } from '$lib/components/ui/button'
+  import { storageErrorStore } from '$lib/stores/storage-error.svelte'
+</script>
+
+<!-- Persistent, non-dismissable: while saving fails, every edit lives only in
+     this tab's memory, so the user must keep seeing the warning until a write
+     succeeds (persist() clears the store on success). -->
+{#if storageErrorStore.hasError}
+  <div class="fixed inset-x-0 bottom-0 z-50 flex justify-center p-4">
+    <Alert.Root variant="destructive" class="max-w-xl border-destructive shadow-lg">
+      <TriangleAlert class="size-4" />
+      <Alert.Title>{$_('storageError.title')}</Alert.Title>
+      <Alert.Description>
+        {$_('storageError.description')}
+        <Button variant="outline" size="sm" class="mt-2 text-foreground" onclick={downloadBackup}>
+          <FileDown class="size-4" />
+          {$_('storageError.export')}
+        </Button>
+      </Alert.Description>
+    </Alert.Root>
+  </div>
+{/if}

--- a/src/lib/components/storage-error-banner.svelte
+++ b/src/lib/components/storage-error-banner.svelte
@@ -17,9 +17,17 @@
   <div class="fixed inset-x-0 bottom-0 z-50 flex justify-center p-4">
     <Alert.Root variant="destructive" class="max-w-xl border-destructive shadow-lg">
       <TriangleAlert class="size-4" />
-      <Alert.Title>{$_('storageError.title')}</Alert.Title>
+      {#if storageErrorStore.kind === 'validation'}
+        <Alert.Title>{$_('storageError.validation.title')}</Alert.Title>
+      {:else}
+        <Alert.Title>{$_('storageError.write.title')}</Alert.Title>
+      {/if}
       <Alert.Description>
-        {$_('storageError.description')}
+        {#if storageErrorStore.kind === 'validation'}
+          {$_('storageError.validation.description')}
+        {:else}
+          {$_('storageError.write.description')}
+        {/if}
         <Button variant="outline" size="sm" class="mt-2 text-foreground" onclick={downloadBackup}>
           <FileDown class="size-4" />
           {$_('storageError.export')}

--- a/src/lib/components/storage-recovery-dialog.svelte
+++ b/src/lib/components/storage-recovery-dialog.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  import { _ } from 'svelte-i18n'
+
+  import FileDown from '@lucide/svelte/icons/file-down'
+
+  import { downloadTextAsFile } from '$lib/backup'
+  import { Button } from '$lib/components/ui/button'
+  import * as Dialog from '$lib/components/ui/dialog'
+  import { loadErrorStore } from '$lib/stores/load-error.svelte'
+
+  function downloadOriginal(): void {
+    if (!loadErrorStore.error) return
+    downloadTextAsFile(
+      `kalkul-data-recovery-${new Date().toISOString().slice(0, 10)}.json`,
+      loadErrorStore.error.raw,
+    )
+  }
+
+  function handleOpenChange(open: boolean): void {
+    if (!open) loadErrorStore.dismiss()
+  }
+</script>
+
+<!-- Shown when stored data failed to parse on load. The original payload has
+     already been quarantined under a recovery key (or kept in memory if even
+     that write failed), so dismissing is safe — but the download is offered
+     front and center before the user continues with the salvaged subset. -->
+<Dialog.Root open={loadErrorStore.error !== undefined} onOpenChange={handleOpenChange}>
+  <Dialog.Content class="sm:max-w-[576px]">
+    <Dialog.Header>
+      <Dialog.Title>{$_('storageRecovery.title')}</Dialog.Title>
+      <Dialog.Description class="text-base text-foreground">
+        {$_('storageRecovery.description')}
+      </Dialog.Description>
+    </Dialog.Header>
+    <p class="text-base font-bold text-foreground">
+      {$_('storageRecovery.warning')}
+    </p>
+    <Dialog.Footer class="sm:justify-start">
+      <Button onclick={downloadOriginal}>
+        <FileDown class="size-4" />
+        {$_('storageRecovery.download')}
+      </Button>
+      <Button variant="outline" onclick={() => loadErrorStore.dismiss()}>
+        {$_('storageRecovery.continue')}
+      </Button>
+    </Dialog.Footer>
+  </Dialog.Content>
+</Dialog.Root>

--- a/src/lib/components/ui/alert/alert-description.svelte
+++ b/src/lib/components/ui/alert/alert-description.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import type { HTMLAttributes } from 'svelte/elements'
+
+  import { type WithElementRef, cn } from '$lib/utils'
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props()
+</script>
+
+<div
+  bind:this={ref}
+  data-slot="alert-description"
+  class={cn(
+    'text-muted-foreground col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed',
+    className,
+  )}
+  {...restProps}
+>
+  {@render children?.()}
+</div>

--- a/src/lib/components/ui/alert/alert-title.svelte
+++ b/src/lib/components/ui/alert/alert-title.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import type { HTMLAttributes } from 'svelte/elements'
+
+  import { type WithElementRef, cn } from '$lib/utils'
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props()
+</script>
+
+<div
+  bind:this={ref}
+  data-slot="alert-title"
+  class={cn('col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight', className)}
+  {...restProps}
+>
+  {@render children?.()}
+</div>

--- a/src/lib/components/ui/alert/alert.svelte
+++ b/src/lib/components/ui/alert/alert.svelte
@@ -1,0 +1,45 @@
+<script lang="ts" module>
+  import { type VariantProps, tv } from 'tailwind-variants'
+
+  export const alertVariants = tv({
+    base: 'relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 rounded-lg border px-4 py-3 text-sm has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-[>svg]:gap-x-3 [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current',
+    variants: {
+      variant: {
+        default: 'bg-card text-card-foreground',
+        destructive:
+          'text-destructive bg-card *:data-[slot=alert-description]:text-destructive/90 [&>svg]:text-current',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  })
+
+  export type AlertVariant = VariantProps<typeof alertVariants>['variant']
+</script>
+
+<script lang="ts">
+  import type { HTMLAttributes } from 'svelte/elements'
+
+  import { type WithElementRef, cn } from '$lib/utils'
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    variant = 'default',
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
+    variant?: AlertVariant
+  } = $props()
+</script>
+
+<div
+  bind:this={ref}
+  data-slot="alert"
+  role="alert"
+  class={cn(alertVariants({ variant }), className)}
+  {...restProps}
+>
+  {@render children?.()}
+</div>

--- a/src/lib/components/ui/alert/index.ts
+++ b/src/lib/components/ui/alert/index.ts
@@ -1,0 +1,15 @@
+import Description from './alert-description.svelte'
+import Title from './alert-title.svelte'
+import Root from './alert.svelte'
+
+export { alertVariants, type AlertVariant } from './alert.svelte'
+
+export {
+  Root,
+  Description,
+  Title,
+  //
+  Root as Alert,
+  Description as AlertDescription,
+  Title as AlertTitle,
+}

--- a/src/lib/locales/cs.json
+++ b/src/lib/locales/cs.json
@@ -375,8 +375,14 @@
     "system": "Systém"
   },
   "storageError": {
-    "title": "Změny se neukládají",
-    "description": "Prohlížeč blokuje ukládání dat (úložiště může být plné nebo omezené), poslední změny proto existují jen v této záložce. Exportujte si zálohu, ať o ně nepřijdete.",
+    "write": {
+      "title": "Změny se neukládají",
+      "description": "Prohlížeč blokuje ukládání dat (úložiště může být plné nebo omezené), poslední změny proto existují jen v této záložce. Exportujte si zálohu, ať o ně nepřijdete."
+    },
+    "validation": {
+      "title": "Poslední změnu se nepodařilo uložit",
+      "description": "Kalkul odmítl uložit neplatnou změnu, aby ochránil vaše uložená data — jde o chybu aplikace, prosíme nahlaste ji. Poslední změny existují jen v této záložce; exportujte si zálohu, ať o ně nepřijdete."
+    },
     "export": "Exportovat zálohu"
   },
   "navbar": {

--- a/src/lib/locales/cs.json
+++ b/src/lib/locales/cs.json
@@ -385,6 +385,13 @@
     },
     "export": "Exportovat zálohu"
   },
+  "storageRecovery": {
+    "title": "Část uložených dat se nepodařilo načíst",
+    "description": "Data uložená v tomto prohlížeči neodpovídají tomu, co Kalkul očekává — to se může stát po aktualizaci aplikace nebo při zásahu do úložiště. Vše, co šlo obnovit, bylo načteno.",
+    "warning": "Vaše původní data zůstala zachována. Stáhněte si je, ať o nic nepřijdete, a poté pokračujte.",
+    "download": "Stáhnout původní data",
+    "continue": "Pokračovat"
+  },
   "navbar": {
     "menu": {
       "exportData": "Exportovat data",

--- a/src/lib/locales/cs.json
+++ b/src/lib/locales/cs.json
@@ -374,6 +374,11 @@
     "dark": "Tmavý",
     "system": "Systém"
   },
+  "storageError": {
+    "title": "Změny se neukládají",
+    "description": "Prohlížeč blokuje ukládání dat (úložiště může být plné nebo omezené), poslední změny proto existují jen v této záložce. Exportujte si zálohu, ať o ně nepřijdete.",
+    "export": "Exportovat zálohu"
+  },
   "navbar": {
     "menu": {
       "exportData": "Exportovat data",

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -375,8 +375,14 @@
     "system": "System"
   },
   "storageError": {
-    "title": "Changes are not being saved",
-    "description": "Your browser is blocking local storage (it may be full or restricted), so recent changes exist only in this tab. Export a backup now so you don't lose them.",
+    "write": {
+      "title": "Changes are not being saved",
+      "description": "Your browser is blocking local storage (it may be full or restricted), so recent changes exist only in this tab. Export a backup now so you don't lose them."
+    },
+    "validation": {
+      "title": "Your latest change could not be saved",
+      "description": "Kalkul refused to save an invalid change to protect your stored data — this is a bug, please report it. Recent changes exist only in this tab; export a backup so you don't lose them."
+    },
     "export": "Export backup"
   },
   "navbar": {

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -374,6 +374,11 @@
     "dark": "Dark",
     "system": "System"
   },
+  "storageError": {
+    "title": "Changes are not being saved",
+    "description": "Your browser is blocking local storage (it may be full or restricted), so recent changes exist only in this tab. Export a backup now so you don't lose them.",
+    "export": "Export backup"
+  },
   "navbar": {
     "menu": {
       "exportData": "Export data",

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -385,6 +385,13 @@
     },
     "export": "Export backup"
   },
+  "storageRecovery": {
+    "title": "Some of your stored data could not be loaded",
+    "description": "The data saved in this browser does not match what Kalkul expects — this can happen after an app update or if the storage was modified. Everything that could be recovered has been loaded.",
+    "warning": "Your original data has been preserved. Download it now so nothing is lost, then continue.",
+    "download": "Download original data",
+    "continue": "Continue"
+  },
   "navbar": {
     "menu": {
       "exportData": "Export data",

--- a/src/lib/schemas.test.ts
+++ b/src/lib/schemas.test.ts
@@ -6,6 +6,7 @@ import en from './locales/en.json'
 import {
   expenseSchema,
   incomeSchema,
+  planDraftSchema,
   repairStoredCashFlowMonths,
   storedDataSchema,
   timingComplete,
@@ -293,5 +294,22 @@ describe('repairStoredCashFlowMonths', () => {
       profile: 'malformed',
       portfolios: 42,
     })
+  })
+})
+
+describe('planDraftSchema', () => {
+  it('accepts the shape the details step writes', () => {
+    const result = planDraftSchema.safeParse({
+      name: 'Retirement',
+      notes: 'First attempt',
+      start_date: '2026-07-01',
+      end_date: '2060-01-01',
+      inflation_rate: 0.02,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects a draft missing required fields', () => {
+    expect(planDraftSchema.safeParse({ name: 'Broken' }).success).toBe(false)
   })
 })

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -463,6 +463,19 @@ export const storedDataSchema = z.object({
   portfolios: z.array(portfolioSchema),
 })
 
+/**
+ * In-progress add-plan wizard draft persisted to sessionStorage between the
+ * details and data steps. Shared by the writer (details page) and reader
+ * (data page) so the two can never drift apart.
+ */
+export const planDraftSchema = z.object({
+  name: z.string(),
+  notes: z.string().optional(),
+  start_date: z.string(),
+  end_date: z.string(),
+  inflation_rate: z.number(),
+})
+
 // --- Derived types ---
 
 export type EntryFeeType = z.infer<typeof entryFeeTypeSchema>
@@ -476,6 +489,7 @@ export type Income = z.infer<typeof incomeSchema>
 export type Expense = z.infer<typeof expenseSchema>
 export type Profile = z.infer<typeof profileSchema>
 export type Portfolio = z.infer<typeof portfolioSchema>
+export type PlanDraft = z.infer<typeof planDraftSchema>
 export type Transfer = z.infer<typeof transferSchema>
 export type TransferSchedule = z.infer<typeof transferScheduleSchema>
 export type StoredData = z.infer<typeof storedDataSchema>

--- a/src/lib/storage-keys.ts
+++ b/src/lib/storage-keys.ts
@@ -13,6 +13,12 @@
 export default {
   /** localStorage — persisted app data (profile, portfolios, plans). */
   DATA: 'kalkul-data',
+  /**
+   * localStorage — prefix for quarantined copies of unparseable app data
+   * (suffixed with a timestamp). Written before anything can overwrite DATA
+   * so the user's original payload survives a failed load.
+   */
+  DATA_CORRUPT_PREFIX: 'kalkul-data-corrupt-',
   /** sessionStorage — in-progress add-plan wizard draft. */
   PLAN_DRAFT: 'kalkul-plan-draft',
   /** localStorage — selected color theme ('light' | 'dark' | 'system'). */

--- a/src/lib/stores/app.svelte.test.ts
+++ b/src/lib/stores/app.svelte.test.ts
@@ -1,8 +1,17 @@
+import { addMessages, init } from 'svelte-i18n'
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import en from '$lib/locales/en.json'
 import storageKeys from '$lib/storage-keys'
 
 import { appStore } from './app.svelte'
+import { storageErrorStore } from './storage-error.svelte'
+
+// Schema refinements resolve their error messages through svelte-i18n at
+// parse time, so the locale must be initialized before any failing parse.
+addMessages('en', en)
+init({ fallbackLocale: 'en', initialLocale: 'en' })
 
 describe('appStore.clear', () => {
   let backing: Map<string, string>
@@ -37,5 +46,85 @@ describe('appStore.clear', () => {
     expect(appStore.portfolios).toEqual([])
     expect(appStore.loading).toBe(false)
     expect(backing.has(storageKeys.DATA)).toBe(false)
+  })
+})
+
+describe('appStore.persist validation gate', () => {
+  let backing: Map<string, string>
+
+  beforeEach(() => {
+    backing = new Map<string, string>()
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => (backing.has(key) ? backing.get(key) : undefined),
+      setItem: (key: string, value: string) => {
+        backing.set(key, value)
+      },
+      removeItem: (key: string) => {
+        backing.delete(key)
+      },
+    })
+    appStore.clear()
+    storageErrorStore.clear()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  function addValidPlan(): string {
+    appStore.updateProfile({ name: 'Test' })
+    return appStore.addPortfolio({
+      name: 'Plan',
+      start_date: '2026-01-01',
+      end_date: '2040-01-01',
+      inflation_rate: 0.02,
+    })
+  }
+
+  it('persists valid portfolio writes and keeps the error store clear', () => {
+    const id = addValidPlan()
+    expect(storageErrorStore.hasError).toBe(false)
+    const raw = backing.get(storageKeys.DATA)
+    expect(raw).toBeDefined()
+    expect(JSON.parse(raw ?? '').portfolios[0].id).toBe(id)
+  })
+
+  it('refuses to persist a write the read path would reject', () => {
+    const id = addValidPlan()
+    const before = backing.get(storageKeys.DATA)
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // A transfer with identical endpoints violates the transfer refinement;
+    // portfolio.update() itself has no validation, so only the persist()
+    // gate stands between this write and a dataset that bricks on reload.
+    appStore.portfolios
+      .find((p) => p.id === id)
+      ?.update({
+        transfers: [
+          {
+            id: 't1',
+            name: 'Broken',
+            from_asset_id: 'cash',
+            to_asset_id: 'cash',
+            amount: 100,
+            schedule: 'one_time',
+            transaction_year: 2030,
+            transaction_month: 1,
+          },
+        ],
+      })
+
+    expect(storageErrorStore.kind).toBe('validation')
+    // The stored payload is untouched — reloading still works.
+    expect(backing.get(storageKeys.DATA)).toBe(before)
+    expect(consoleError).toHaveBeenCalled()
+    consoleError.mockRestore()
+  })
+
+  it('clears the error once a subsequent valid write persists', () => {
+    addValidPlan()
+    storageErrorStore.setError('validation')
+    appStore.updateProfile({ name: 'Renamed' })
+    expect(storageErrorStore.hasError).toBe(false)
   })
 })

--- a/src/lib/stores/app.svelte.test.ts
+++ b/src/lib/stores/app.svelte.test.ts
@@ -296,3 +296,229 @@ describe('appStore.load corrupt-data recovery', () => {
     expect(recoveryKeys()).toHaveLength(1)
   })
 })
+
+describe('appStore persistence round-trips', () => {
+  let backing: Map<string, string>
+
+  beforeEach(() => {
+    backing = new Map<string, string>()
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => (backing.has(key) ? backing.get(key) : undefined),
+      setItem: (key: string, value: string) => {
+        backing.set(key, value)
+      },
+      removeItem: (key: string) => {
+        backing.delete(key)
+      },
+    })
+    appStore.clear()
+    storageErrorStore.clear()
+    loadErrorStore.dismiss()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  // A realistic profile built through the public API only.
+  function buildState(): string {
+    appStore.updateProfile({
+      name: 'Jane',
+      email: 'jane@example.com',
+      birth_date: '1990-06-01',
+      location: 'CZ',
+      currency: 'CZK',
+      cash_amount: 250_000,
+      investments: [{ id: 'inv-1', name: 'ETF', balance: 800_000, apy: 7 }],
+      liabilities: [
+        {
+          id: 'liab-1',
+          name: 'Loan',
+          outstanding_balance: 120_000,
+          installment_frequency: 'monthly',
+          annual_rate: 3.5,
+          installment_amount: 2_000,
+          remaining_term: 6,
+        },
+      ],
+      incomes: [
+        {
+          id: 'income-1',
+          name: 'Salary',
+          amount: 65_000,
+          frequency: 'monthly',
+          withhold_taxes: false,
+          start: 'immediately',
+          end: 'never',
+          change_over_time: 'none',
+        },
+      ],
+    })
+    return appStore.addPortfolio({
+      name: 'Plan',
+      notes: 'Base',
+      start_date: '2026-07-01',
+      end_date: '2055-06-01',
+      inflation_rate: 0.02,
+      include_cash: true,
+      included_investment_ids: ['inv-1'],
+      transfers: [
+        {
+          id: 't1',
+          name: 'Invest monthly',
+          from_asset_id: 'cash',
+          to_asset_id: 'inv-1',
+          amount: 10_000,
+          schedule: 'recurring',
+          frequency: 'monthly',
+          start: 'immediately',
+          end: 'never',
+          change_over_time: 'none',
+        },
+      ],
+    })
+  }
+
+  it('re-loads every mutation the public API produced (the wipe-path guard)', () => {
+    const portfolioId = buildState()
+    const profileBefore = appStore.profile.toJSON()
+    const portfoliosBefore = appStore.portfolios.map((p) => p.toJSON())
+
+    appStore.load()
+
+    expect(appStore.profile.toJSON()).toEqual(profileBefore)
+    expect(appStore.portfolios.map((p) => p.toJSON())).toEqual(portfoliosBefore)
+    expect(appStore.portfolios[0].id).toBe(portfolioId)
+    expect(loadErrorStore.error).toBeUndefined()
+  })
+
+  it('round-trips through export + import', () => {
+    buildState()
+    const profileBefore = appStore.profile.toJSON()
+    const portfoliosBefore = appStore.portfolios.map((p) => p.toJSON())
+
+    const backup = appStore.exportBackup()
+    appStore.clear()
+    expect(appStore.profile.name).toBe('')
+    appStore.importBackup(backup)
+
+    expect(appStore.profile.toJSON()).toEqual(profileBefore)
+    expect(appStore.portfolios.map((p) => p.toJSON())).toEqual(portfoliosBefore)
+  })
+
+  it('rejects a malformed backup without touching current data', () => {
+    buildState()
+    const before = backing.get(storageKeys.DATA)
+    expect(() => appStore.importBackup('{not json')).toThrow()
+    expect(() => appStore.importBackup('{"profile": 42}')).toThrow()
+    expect(appStore.profile.name).toBe('Jane')
+    expect(backing.get(storageKeys.DATA)).toBe(before)
+  })
+
+  it('updateProfile rejects invalid updates without persisting partial state', () => {
+    buildState()
+    const before = backing.get(storageKeys.DATA)
+    expect(() =>
+      appStore.updateProfile({
+        incomes: [
+          {
+            id: 'income-2',
+            name: 'Broken',
+            amount: 100,
+            frequency: 'monthly',
+            withhold_taxes: false,
+            start: 'when_age_is', // start_age missing -> refinement fails
+            end: 'never',
+            change_over_time: 'none',
+          },
+        ],
+      }),
+    ).toThrow()
+    // Neither memory nor storage picked up the invalid write.
+    expect(appStore.profile.incomes?.map((i) => i.id)).toEqual(['income-1'])
+    expect(backing.get(storageKeys.DATA)).toBe(before)
+  })
+})
+
+describe('appStore.startSync', () => {
+  let backing: Map<string, string>
+  let storageHandler: ((event: StorageEvent) => void) | undefined
+
+  beforeEach(() => {
+    backing = new Map<string, string>()
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => (backing.has(key) ? backing.get(key) : undefined),
+      setItem: (key: string, value: string) => {
+        backing.set(key, value)
+      },
+      removeItem: (key: string) => {
+        backing.delete(key)
+      },
+    })
+    vi.stubGlobal('window', {
+      addEventListener: (_type: string, handler: (event: StorageEvent) => void) => {
+        storageHandler = handler
+      },
+      removeEventListener: () => {
+        storageHandler = undefined
+      },
+    })
+    appStore.clear()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  function syncEvent(newValue: string | undefined): StorageEvent {
+    return { key: storageKeys.DATA, newValue } as StorageEvent
+  }
+
+  it('applies a newer payload from another tab', () => {
+    appStore.updateProfile({ name: 'Old' })
+    const cleanup = appStore.startSync()
+
+    storageHandler?.(
+      syncEvent(
+        JSON.stringify({
+          lastUpdated: appStore.lastUpdated + 1000,
+          profile: { name: 'From other tab', email: '' },
+          portfolios: [],
+        }),
+      ),
+    )
+
+    expect(appStore.profile.name).toBe('From other tab')
+    cleanup()
+  })
+
+  it('ignores an event with the lastUpdated it already has', () => {
+    appStore.updateProfile({ name: 'Current' })
+    const cleanup = appStore.startSync()
+
+    storageHandler?.(
+      syncEvent(
+        JSON.stringify({
+          lastUpdated: appStore.lastUpdated,
+          profile: { name: 'Echo of self', email: '' },
+          portfolios: [],
+        }),
+      ),
+    )
+
+    expect(appStore.profile.name).toBe('Current')
+    cleanup()
+  })
+
+  it('ignores malformed payloads from other tabs', () => {
+    appStore.updateProfile({ name: 'Current' })
+    const cleanup = appStore.startSync()
+
+    storageHandler?.(syncEvent('{definitely not json'))
+    storageHandler?.(syncEvent(JSON.stringify({ lastUpdated: 'nope' })))
+    storageHandler?.(syncEvent(undefined))
+
+    expect(appStore.profile.name).toBe('Current')
+    cleanup()
+  })
+})

--- a/src/lib/stores/app.svelte.test.ts
+++ b/src/lib/stores/app.svelte.test.ts
@@ -6,6 +6,7 @@ import en from '$lib/locales/en.json'
 import storageKeys from '$lib/storage-keys'
 
 import { appStore } from './app.svelte'
+import { loadErrorStore } from './load-error.svelte'
 import { storageErrorStore } from './storage-error.svelte'
 
 // Schema refinements resolve their error messages through svelte-i18n at
@@ -126,5 +127,172 @@ describe('appStore.persist validation gate', () => {
     storageErrorStore.setError('validation')
     appStore.updateProfile({ name: 'Renamed' })
     expect(storageErrorStore.hasError).toBe(false)
+  })
+})
+
+describe('appStore.load corrupt-data recovery', () => {
+  let backing: Map<string, string>
+
+  beforeEach(() => {
+    backing = new Map<string, string>()
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => (backing.has(key) ? backing.get(key) : undefined),
+      setItem: (key: string, value: string) => {
+        backing.set(key, value)
+      },
+      removeItem: (key: string) => {
+        backing.delete(key)
+      },
+    })
+    loadErrorStore.dismiss()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  function recoveryKeys(): string[] {
+    return [...backing.keys()].filter((k) => k.startsWith(storageKeys.DATA_CORRUPT_PREFIX))
+  }
+
+  const validPortfolio = {
+    id: 'p1',
+    name: 'Plan',
+    start_date: '2026-01-01',
+    end_date: '2040-01-01',
+    inflation_rate: 0.02,
+  }
+
+  it('loads defaults without a recovery state when no data is stored', () => {
+    appStore.load()
+    expect(appStore.profile.name).toBe('')
+    expect(loadErrorStore.error).toBeUndefined()
+    expect(recoveryKeys()).toEqual([])
+  })
+
+  it('quarantines unparseable JSON before it can be overwritten', () => {
+    backing.set(storageKeys.DATA, '{definitely not json')
+    appStore.load()
+
+    // The raw payload survives under a recovery key and in the error store.
+    expect(recoveryKeys()).toHaveLength(1)
+    expect(backing.get(recoveryKeys()[0])).toBe('{definitely not json')
+    expect(loadErrorStore.error?.raw).toBe('{definitely not json')
+    expect(loadErrorStore.error?.recoveryKey).toBe(recoveryKeys()[0])
+
+    // A subsequent persist overwrites the main key but not the quarantine.
+    appStore.updateProfile({ name: 'After' })
+    expect(backing.get(recoveryKeys()[0])).toBe('{definitely not json')
+  })
+
+  it('salvages the valid portfolios and drops only the invalid one', () => {
+    backing.set(
+      storageKeys.DATA,
+      JSON.stringify({
+        lastUpdated: 42,
+        profile: { name: 'Jane', email: '' },
+        portfolios: [validPortfolio, { id: 'p2', name: 'Broken' }],
+      }),
+    )
+    appStore.load()
+
+    expect(appStore.profile.name).toBe('Jane')
+    expect(appStore.portfolios.map((p) => p.id)).toEqual(['p1'])
+    expect(appStore.lastUpdated).toBe(42)
+    expect(loadErrorStore.error).toBeDefined()
+  })
+
+  it('salvages the rest of the profile when a single list item is invalid', () => {
+    backing.set(
+      storageKeys.DATA,
+      JSON.stringify({
+        lastUpdated: 1,
+        profile: {
+          name: 'Jane',
+          email: '',
+          cash_amount: 100,
+          incomes: [
+            {
+              id: 'i1',
+              name: 'Salary',
+              amount: 1000,
+              frequency: 'monthly',
+              withhold_taxes: false,
+              start: 'immediately',
+              end: 'never',
+              change_over_time: 'none',
+            },
+            { id: 'i2', name: 'Broken', amount: 'NaN' },
+          ],
+        },
+        portfolios: [],
+      }),
+    )
+    appStore.load()
+
+    expect(appStore.profile.name).toBe('Jane')
+    expect(appStore.profile.cash_amount).toBe(100)
+    expect(appStore.profile.incomes?.map((i) => i.id)).toEqual(['i1'])
+  })
+
+  it('drops only the invalid transfer inside an otherwise valid portfolio', () => {
+    backing.set(
+      storageKeys.DATA,
+      JSON.stringify({
+        lastUpdated: 1,
+        profile: { name: 'Jane', email: '' },
+        portfolios: [
+          {
+            ...validPortfolio,
+            transfers: [
+              {
+                id: 't1',
+                name: 'Valid',
+                from_asset_id: 'cash',
+                to_asset_id: 'inv-1',
+                amount: 100,
+                schedule: 'one_time',
+                transaction_year: 2030,
+                transaction_month: 1,
+              },
+              { id: 't2', name: 'Broken', from_asset_id: 'cash' },
+            ],
+          },
+        ],
+      }),
+    )
+    appStore.load()
+
+    expect(appStore.portfolios).toHaveLength(1)
+    expect(appStore.portfolios[0].transfers?.map((t) => t.id)).toEqual(['t1'])
+  })
+
+  it('falls back to the default profile when scalar profile fields are broken', () => {
+    backing.set(
+      storageKeys.DATA,
+      JSON.stringify({
+        lastUpdated: 1,
+        profile: { name: 42, email: [] },
+        portfolios: [validPortfolio],
+      }),
+    )
+    appStore.load()
+
+    expect(appStore.profile.name).toBe('')
+    // Valid portfolios still survive a broken profile.
+    expect(appStore.portfolios.map((p) => p.id)).toEqual(['p1'])
+  })
+
+  it('salvages nothing but still quarantines a legacy pre-rewrite payload', () => {
+    const legacy = JSON.stringify({ lastUpdated: 1, clients: [{ name: 'Old shape' }] })
+    backing.set(storageKeys.DATA, legacy)
+    appStore.load()
+
+    expect(appStore.profile.name).toBe('')
+    expect(appStore.portfolios).toEqual([])
+    expect(loadErrorStore.error?.raw).toBe(legacy)
+    expect(recoveryKeys()).toHaveLength(1)
   })
 })

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -122,13 +122,25 @@ function withAppStore() {
       profile: profile.toJSON(),
       portfolios: portfolios.map((p) => p.toJSON()),
     }
+    // Never write data the read path would reject: loadData() enforces the
+    // full schema, so an invalid write would persist fine today and brick the
+    // whole dataset on the next load. updateProfile validates the profile,
+    // but portfolio writes (update()/addPortfolio) have no gate of their own
+    // — this is the one place that covers them all.
+    const validated = storedDataSchema.safeParse(stored)
+    if (!validated.success) {
+      console.error('Refusing to persist data that would fail to load', validated.error)
+      storageErrorStore.setError('validation')
+      portfolios = [...portfolios]
+      return
+    }
     try {
       localStorage.setItem(storageKeys.DATA, JSON.stringify(stored))
       lastUpdated = now
       storageErrorStore.clear()
     } catch (e) {
       console.error('Failed to save data to localStorage', e)
-      storageErrorStore.setError()
+      storageErrorStore.setError('write')
     }
     // Trigger reactivity: $state reassignment
     portfolios = [...portfolios]

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -1,10 +1,19 @@
+import { z } from 'zod'
+
 import {
   type Portfolio,
   type Profile,
   type StoredData,
+  expenseSchema,
+  incomeSchema,
+  portfolioSchema,
+  profileInvestmentSchema,
+  profileLiabilitySchema,
   profileSchema,
+  profileTangibleAssetSchema,
   repairStoredCashFlowMonths,
   storedDataSchema,
+  transferSchema,
 } from '$lib/schemas'
 import storageKeys from '$lib/storage-keys'
 import {
@@ -17,6 +26,7 @@ import {
   parseDateOnly,
 } from '$lib/utils'
 
+import { loadErrorStore } from './load-error.svelte'
 import type { PortfolioStore } from './portfolio.svelte'
 import { withPortfolioStore } from './portfolio.svelte'
 import { storageErrorStore } from './storage-error.svelte'
@@ -93,19 +103,114 @@ const DEFAULT_PROFILE: Profile = {
   email: '',
 }
 
-function loadData(): StoredData {
-  try {
-    const raw = localStorage.getItem(storageKeys.DATA)
-    if (raw) {
-      // Repair before parsing: data stored before stricter validation rules
-      // must keep loading, otherwise the whole dataset falls back to the
-      // empty default and gets overwritten on the next persist.
-      return storedDataSchema.parse(repairStoredCashFlowMonths(JSON.parse(raw)))
-    }
-  } catch (e) {
-    console.error('Failed to load data from localStorage', e)
-  }
+function defaultStoredData(): StoredData {
   return { lastUpdated: 0, profile: { ...DEFAULT_PROFILE }, portfolios: [] }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  // null check is for raw JSON.parse output, which can legitimately be null.
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+// Keep only the array elements that individually satisfy the schema.
+// Non-arrays collapse to undefined (every list is optional on the profile).
+function salvageArray<T>(value: unknown, schema: z.ZodType<T>): T[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const valid: T[] = []
+  for (const item of value) {
+    const result = schema.safeParse(item)
+    if (result.success) valid.push(result.data)
+  }
+  return valid
+}
+
+/**
+ * Best-effort recovery of a stored payload that failed full-schema parsing:
+ * drop only the records that are individually invalid instead of discarding
+ * everything. A profile whose scalar fields are broken falls back to the
+ * default profile; invalid list items and portfolios are dropped one by one.
+ * The unparseable original is quarantined separately, so nothing is lost.
+ */
+function salvageStoredData(raw: string): StoredData {
+  let parsed: unknown
+  try {
+    parsed = repairStoredCashFlowMonths(JSON.parse(raw))
+  } catch {
+    return defaultStoredData()
+  }
+  if (!isRecord(parsed)) return defaultStoredData()
+
+  let profile: Profile = { ...DEFAULT_PROFILE }
+  if (isRecord(parsed.profile)) {
+    const candidate = {
+      ...parsed.profile,
+      investments: salvageArray(parsed.profile.investments, profileInvestmentSchema),
+      tangible_assets: salvageArray(parsed.profile.tangible_assets, profileTangibleAssetSchema),
+      liabilities: salvageArray(parsed.profile.liabilities, profileLiabilitySchema),
+      incomes: salvageArray(parsed.profile.incomes, incomeSchema),
+      expenses: salvageArray(parsed.profile.expenses, expenseSchema),
+    }
+    const result = profileSchema.safeParse(candidate)
+    if (result.success) profile = result.data
+  }
+
+  const portfolios: Portfolio[] = []
+  if (Array.isArray(parsed.portfolios)) {
+    for (const entry of parsed.portfolios) {
+      // Drop invalid transfers individually before judging the portfolio.
+      const candidate = isRecord(entry)
+        ? { ...entry, transfers: salvageArray(entry.transfers, transferSchema) }
+        : entry
+      const result = portfolioSchema.safeParse(candidate)
+      if (result.success) portfolios.push(result.data)
+    }
+  }
+
+  return {
+    lastUpdated: typeof parsed.lastUpdated === 'number' ? parsed.lastUpdated : 0,
+    profile,
+    portfolios,
+  }
+}
+
+/**
+ * Copy the unparseable payload to a timestamped recovery key BEFORE anything
+ * can overwrite the main key (the first persist() after a failed load would
+ * otherwise destroy the only copy of the user's data), then surface the
+ * recovery dialog.
+ */
+function quarantineCorruptData(raw: string): void {
+  const key = `${storageKeys.DATA_CORRUPT_PREFIX}${Date.now()}`
+  let recoveryKey: string | undefined
+  try {
+    localStorage.setItem(key, raw)
+    recoveryKey = key
+  } catch (e) {
+    console.error('Failed to write the recovery copy; keeping it in memory only', e)
+  }
+  loadErrorStore.set({ raw, recoveryKey })
+}
+
+function loadData(): StoredData {
+  let raw: string | undefined
+  try {
+    raw = localStorage.getItem(storageKeys.DATA) ?? undefined
+  } catch (e) {
+    console.error('Failed to read data from localStorage', e)
+    return defaultStoredData()
+  }
+  // No stored data: a genuinely fresh install, not an error.
+  if (!raw) return defaultStoredData()
+  try {
+    // Repair before parsing: data stored before stricter validation rules
+    // must keep loading, otherwise the whole dataset falls back to the
+    // empty default and gets overwritten on the next persist.
+    return storedDataSchema.parse(repairStoredCashFlowMonths(JSON.parse(raw)))
+  } catch (e) {
+    console.error('Stored data failed to parse; quarantining the original and salvaging', e)
+    quarantineCorruptData(raw)
+    return salvageStoredData(raw)
+  }
 }
 
 function withAppStore() {

--- a/src/lib/stores/load-error.svelte.ts
+++ b/src/lib/stores/load-error.svelte.ts
@@ -1,0 +1,33 @@
+export type LoadError = {
+  /** The raw unparseable payload, kept in memory for download. */
+  raw: string
+  /**
+   * localStorage key holding the quarantined copy of `raw`, or undefined if
+   * writing the quarantine copy itself failed (e.g. quota) — the in-memory
+   * `raw` is then the only surviving copy.
+   */
+  recoveryKey: string | undefined
+}
+
+function withLoadErrorStore() {
+  let error = $state<LoadError | undefined>(undefined)
+
+  return {
+    get error() {
+      return error
+    },
+    set(newError: LoadError) {
+      error = newError
+    },
+    dismiss() {
+      error = undefined
+    },
+  }
+}
+
+/**
+ * Set when loadData() finds stored data it cannot parse. The recovery dialog
+ * in the root layout consumes it, offering a download of the original payload
+ * before the user continues with whatever could be salvaged.
+ */
+export const loadErrorStore = withLoadErrorStore()

--- a/src/lib/stores/portfolio.svelte.ts
+++ b/src/lib/stores/portfolio.svelte.ts
@@ -5,14 +5,17 @@ type AppParent = {
   deletePortfolio(id: string): void
 }
 
-export type PortfolioStore = Portfolio & {
+// `id` is readonly: identity is assigned once at creation and nothing may
+// rewrite it afterwards (update() also excludes it).
+export type PortfolioStore = Omit<Portfolio, 'id'> & {
+  readonly id: string
   update(updates: Partial<Omit<Portfolio, 'id'>>): void
   delete(): void
   toJSON(): Portfolio
 }
 
 export function withPortfolioStore(portfolio: Portfolio, app: AppParent): PortfolioStore {
-  let id = $state(portfolio.id)
+  const id = portfolio.id
   let name = $state(portfolio.name)
   let notes = $state(portfolio.notes)
   let start_date = $state(portfolio.start_date)
@@ -32,9 +35,6 @@ export function withPortfolioStore(portfolio: Portfolio, app: AppParent): Portfo
   return {
     get id() {
       return id
-    },
-    set id(v) {
-      id = v
     },
     get name() {
       return name

--- a/src/lib/stores/storage-error.svelte.ts
+++ b/src/lib/stores/storage-error.svelte.ts
@@ -1,15 +1,23 @@
+// 'write' — localStorage.setItem threw (quota exceeded, private mode, …).
+// 'validation' — persist() refused to write data the read path would reject
+// (a bug upstream of persist; writing it would brick the dataset on reload).
+export type StorageErrorKind = 'write' | 'validation'
+
 function withStorageErrorStore() {
-  let hasError = $state(false)
+  let kind = $state<StorageErrorKind | undefined>(undefined)
 
   return {
     get hasError() {
-      return hasError
+      return kind !== undefined
     },
-    setError() {
-      hasError = true
+    get kind() {
+      return kind
+    },
+    setError(newKind: StorageErrorKind = 'write') {
+      kind = newKind
     },
     clear() {
-      hasError = false
+      kind = undefined
     },
   }
 }

--- a/src/routes/(add-plan)/plan/add/data/+page.svelte
+++ b/src/routes/(add-plan)/plan/add/data/+page.svelte
@@ -13,6 +13,7 @@
   import { Label } from '$lib/components/ui/label'
   import { Separator } from '$lib/components/ui/separator'
   import routes from '$lib/routes'
+  import { type PlanDraft, planDraftSchema } from '$lib/schemas'
   import storageKeys from '$lib/storage-keys'
   import { appStore } from '$lib/stores/app.svelte'
 
@@ -110,12 +111,22 @@
       return
     }
 
-    const draft = JSON.parse(draftStr) as {
-      name: string
-      notes?: string
-      start_date: string
-      end_date: string
-      inflation_rate: number
+    // Validate the draft instead of blind-casting: a corrupted or outdated
+    // draft would otherwise flow unchecked into addPortfolio and make the
+    // Create button throw. On failure, drop it and return to the details
+    // step so the user can re-enter the plan basics.
+    let draft: PlanDraft | undefined
+    try {
+      draft = planDraftSchema.parse(JSON.parse(draftStr))
+    } catch (e) {
+      console.error('Discarding unparseable plan draft', e)
+    }
+    if (!draft) {
+      sessionStorage.removeItem(storageKeys.PLAN_DRAFT)
+      // URL is already resolved by getPrevAddPlanStepUrl
+      // eslint-disable-next-line svelte/no-navigation-without-resolve
+      goto(getPrevAddPlanStepUrl(routes.PLAN_ADD_DATA, appStore.profile))
+      return
     }
 
     // Create the portfolio with included references

--- a/src/routes/(add-plan)/plan/add/details/+page.svelte
+++ b/src/routes/(add-plan)/plan/add/details/+page.svelte
@@ -14,7 +14,7 @@
   import { Label } from '$lib/components/ui/label'
   import { Textarea } from '$lib/components/ui/textarea'
   import routes from '$lib/routes'
-  import type { PlanEndType, PlanStartType } from '$lib/schemas'
+  import type { PlanDraft, PlanEndType, PlanStartType } from '$lib/schemas'
   import storageKeys from '$lib/storage-keys'
   import { appStore } from '$lib/stores/app.svelte'
   import { getMonthOptions, getYearOptions } from '$lib/utils'
@@ -89,8 +89,9 @@
   }
 
   function handleContinue() {
-    // Store plan details in sessionStorage for step 3
-    const planDetails = {
+    // Store plan details in sessionStorage for step 3. The data step parses
+    // this with planDraftSchema, so the type keeps writer and reader in sync.
+    const planDetails: PlanDraft = {
       name: name.trim(),
       notes: notes.trim() || undefined,
       start_date: getStartDate(),

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
   import { onDestroy, onMount } from 'svelte'
   import { locale } from 'svelte-i18n'
 
+  import StorageErrorBanner from '$lib/components/storage-error-banner.svelte'
   import { appStore } from '$lib/stores/app.svelte'
 
   import '../app.css'
@@ -26,3 +27,4 @@
 </script>
 
 {@render children()}
+<StorageErrorBanner />

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,6 +3,7 @@
   import { locale } from 'svelte-i18n'
 
   import StorageErrorBanner from '$lib/components/storage-error-banner.svelte'
+  import StorageRecoveryDialog from '$lib/components/storage-recovery-dialog.svelte'
   import { appStore } from '$lib/stores/app.svelte'
 
   import '../app.css'
@@ -28,3 +29,4 @@
 
 {@render children()}
 <StorageErrorBanner />
+<StorageRecoveryDialog />


### PR DESCRIPTION
Makes localStorage persistence safe end to end — the four data-safety issues form one dependency chain (the banner is the surface the later fixes report through), so they ship together as one reviewable unit, one commit each:

1. **Surface write failures** (#105): persist() recorded quota/private-mode failures in storageErrorStore, but the banner consuming it was lost in the shadcn rewrite — every edit appeared to succeed while nothing persisted. A persistent, non-dismissable destructive alert in the root layout now shows while writes fail, offering the existing backup export (extracted into a shared downloadBackup helper). Clears on the next successful write.

2. **Validate writes at the persist boundary** (#104): only profile writes were validated; addPortfolio and PortfolioStore.update() persisted anything, and the add-plan wizard blind-cast its sessionStorage draft. Because the read path enforces the full schema, any invalid write bricked the dataset on the next load. persist() now safeParses the assembled StoredData and refuses the write (surfacing a distinct 'validation' banner state), the wizard draft has a shared planDraftSchema, and the portfolio store's public id setter is gone.

3. **Quarantine + salvage instead of wiping** (#99): loadData() swallowed parse failures and returned the empty default, so the first persist() overwrote the still-intact payload — destroying the only copy of the user's data. On parse failure the raw payload is now copied to a timestamped kalkul-data-corrupt-* key before anything can overwrite it, a recovery dialog offers downloading the original, and loading salvages record-by-record (invalid items/transfers/portfolios dropped individually; broken scalar profile fields fall back to defaults). Fresh installs are distinguished from corruption and raise no error.

4. **Store-layer test coverage** (#119): persist→load round-trip built through the public API (the wipe-path guard), export→import round-trip plus malformed-backup rejection, updateProfile rejecting invalid updates without persisting partial state, and startSync cross-tab reconciliation (newer applied, echoes and malformed events ignored).

Verified in the browser: simulated quota failure shows the banner and clears on recovery; planted corrupt payloads show the recovery dialog with the original preserved under a recovery key.

Closes #105
Closes #104
Closes #99
Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)
