### PR TITLE
fix: quarantine and salvage unparseable stored data instead of wiping it

### DIFF
--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -1,20 +1,27 @@
 import { appStore } from '$lib/stores/app.svelte'
 
+/** Trigger a browser download of `text` as a JSON file named `filename`. */
+export function downloadTextAsFile(filename: string, text: string): void {
+  const blob = new Blob([text], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  // Delay revoke so the browser has time to start the download.
+  setTimeout(() => URL.revokeObjectURL(url), 1000)
+}
+
 /**
  * Serialize the current data via `appStore.exportBackup()` and trigger a
  * browser download of the backup file. Shared by the navbar's export action
  * and the storage-error banner.
  */
 export function downloadBackup(): void {
-  const json = appStore.exportBackup()
-  const blob = new Blob([json], { type: 'application/json' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = `kalkul-backup-${new Date().toISOString().slice(0, 10)}.json`
-  document.body.appendChild(a)
-  a.click()
-  document.body.removeChild(a)
-  // Delay revoke so the browser has time to start the download.
-  setTimeout(() => URL.revokeObjectURL(url), 1000)
+  downloadTextAsFile(
+    `kalkul-backup-${new Date().toISOString().slice(0, 10)}.json`,
+    appStore.exportBackup(),
+  )
 }

--- a/src/lib/components/storage-recovery-dialog.svelte
+++ b/src/lib/components/storage-recovery-dialog.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  import { _ } from 'svelte-i18n'
+
+  import FileDown from '@lucide/svelte/icons/file-down'
+
+  import { downloadTextAsFile } from '$lib/backup'
+  import { Button } from '$lib/components/ui/button'
+  import * as Dialog from '$lib/components/ui/dialog'
+  import { loadErrorStore } from '$lib/stores/load-error.svelte'
+
+  function downloadOriginal(): void {
+    if (!loadErrorStore.error) return
+    downloadTextAsFile(
+      `kalkul-data-recovery-${new Date().toISOString().slice(0, 10)}.json`,
+      loadErrorStore.error.raw,
+    )
+  }
+
+  function handleOpenChange(open: boolean): void {
+    if (!open) loadErrorStore.dismiss()
+  }
+</script>
+
+<!-- Shown when stored data failed to parse on load. The original payload has
+     already been quarantined under a recovery key (or kept in memory if even
+     that write failed), so dismissing is safe — but the download is offered
+     front and center before the user continues with the salvaged subset. -->
+<Dialog.Root open={loadErrorStore.error !== undefined} onOpenChange={handleOpenChange}>
+  <Dialog.Content class="sm:max-w-[576px]">
+    <Dialog.Header>
+      <Dialog.Title>{$_('storageRecovery.title')}</Dialog.Title>
+      <Dialog.Description class="text-base text-foreground">
+        {$_('storageRecovery.description')}
+      </Dialog.Description>
+    </Dialog.Header>
+    <p class="text-base font-bold text-foreground">
+      {$_('storageRecovery.warning')}
+    </p>
+    <Dialog.Footer class="sm:justify-start">
+      <Button onclick={downloadOriginal}>
+        <FileDown class="size-4" />
+        {$_('storageRecovery.download')}
+      </Button>
+      <Button variant="outline" onclick={() => loadErrorStore.dismiss()}>
+        {$_('storageRecovery.continue')}
+      </Button>
+    </Dialog.Footer>
+  </Dialog.Content>
+</Dialog.Root>

--- a/src/lib/locales/cs.json
+++ b/src/lib/locales/cs.json
@@ -385,6 +385,13 @@
     },
     "export": "Exportovat zálohu"
   },
+  "storageRecovery": {
+    "title": "Část uložených dat se nepodařilo načíst",
+    "description": "Data uložená v tomto prohlížeči neodpovídají tomu, co Kalkul očekává — to se může stát po aktualizaci aplikace nebo při zásahu do úložiště. Vše, co šlo obnovit, bylo načteno.",
+    "warning": "Vaše původní data zůstala zachována. Stáhněte si je, ať o nic nepřijdete, a poté pokračujte.",
+    "download": "Stáhnout původní data",
+    "continue": "Pokračovat"
+  },
   "navbar": {
     "menu": {
       "exportData": "Exportovat data",

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -385,6 +385,13 @@
     },
     "export": "Export backup"
   },
+  "storageRecovery": {
+    "title": "Some of your stored data could not be loaded",
+    "description": "The data saved in this browser does not match what Kalkul expects — this can happen after an app update or if the storage was modified. Everything that could be recovered has been loaded.",
+    "warning": "Your original data has been preserved. Download it now so nothing is lost, then continue.",
+    "download": "Download original data",
+    "continue": "Continue"
+  },
   "navbar": {
     "menu": {
       "exportData": "Export data",

--- a/src/lib/storage-keys.ts
+++ b/src/lib/storage-keys.ts
@@ -13,6 +13,12 @@
 export default {
   /** localStorage — persisted app data (profile, portfolios, plans). */
   DATA: 'kalkul-data',
+  /**
+   * localStorage — prefix for quarantined copies of unparseable app data
+   * (suffixed with a timestamp). Written before anything can overwrite DATA
+   * so the user's original payload survives a failed load.
+   */
+  DATA_CORRUPT_PREFIX: 'kalkul-data-corrupt-',
   /** sessionStorage — in-progress add-plan wizard draft. */
   PLAN_DRAFT: 'kalkul-plan-draft',
   /** localStorage — selected color theme ('light' | 'dark' | 'system'). */

--- a/src/lib/stores/app.svelte.test.ts
+++ b/src/lib/stores/app.svelte.test.ts
@@ -6,6 +6,7 @@ import en from '$lib/locales/en.json'
 import storageKeys from '$lib/storage-keys'
 
 import { appStore } from './app.svelte'
+import { loadErrorStore } from './load-error.svelte'
 import { storageErrorStore } from './storage-error.svelte'
 
 // Schema refinements resolve their error messages through svelte-i18n at
@@ -126,5 +127,172 @@ describe('appStore.persist validation gate', () => {
     storageErrorStore.setError('validation')
     appStore.updateProfile({ name: 'Renamed' })
     expect(storageErrorStore.hasError).toBe(false)
+  })
+})
+
+describe('appStore.load corrupt-data recovery', () => {
+  let backing: Map<string, string>
+
+  beforeEach(() => {
+    backing = new Map<string, string>()
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => (backing.has(key) ? backing.get(key) : undefined),
+      setItem: (key: string, value: string) => {
+        backing.set(key, value)
+      },
+      removeItem: (key: string) => {
+        backing.delete(key)
+      },
+    })
+    loadErrorStore.dismiss()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  function recoveryKeys(): string[] {
+    return [...backing.keys()].filter((k) => k.startsWith(storageKeys.DATA_CORRUPT_PREFIX))
+  }
+
+  const validPortfolio = {
+    id: 'p1',
+    name: 'Plan',
+    start_date: '2026-01-01',
+    end_date: '2040-01-01',
+    inflation_rate: 0.02,
+  }
+
+  it('loads defaults without a recovery state when no data is stored', () => {
+    appStore.load()
+    expect(appStore.profile.name).toBe('')
+    expect(loadErrorStore.error).toBeUndefined()
+    expect(recoveryKeys()).toEqual([])
+  })
+
+  it('quarantines unparseable JSON before it can be overwritten', () => {
+    backing.set(storageKeys.DATA, '{definitely not json')
+    appStore.load()
+
+    // The raw payload survives under a recovery key and in the error store.
+    expect(recoveryKeys()).toHaveLength(1)
+    expect(backing.get(recoveryKeys()[0])).toBe('{definitely not json')
+    expect(loadErrorStore.error?.raw).toBe('{definitely not json')
+    expect(loadErrorStore.error?.recoveryKey).toBe(recoveryKeys()[0])
+
+    // A subsequent persist overwrites the main key but not the quarantine.
+    appStore.updateProfile({ name: 'After' })
+    expect(backing.get(recoveryKeys()[0])).toBe('{definitely not json')
+  })
+
+  it('salvages the valid portfolios and drops only the invalid one', () => {
+    backing.set(
+      storageKeys.DATA,
+      JSON.stringify({
+        lastUpdated: 42,
+        profile: { name: 'Jane', email: '' },
+        portfolios: [validPortfolio, { id: 'p2', name: 'Broken' }],
+      }),
+    )
+    appStore.load()
+
+    expect(appStore.profile.name).toBe('Jane')
+    expect(appStore.portfolios.map((p) => p.id)).toEqual(['p1'])
+    expect(appStore.lastUpdated).toBe(42)
+    expect(loadErrorStore.error).toBeDefined()
+  })
+
+  it('salvages the rest of the profile when a single list item is invalid', () => {
+    backing.set(
+      storageKeys.DATA,
+      JSON.stringify({
+        lastUpdated: 1,
+        profile: {
+          name: 'Jane',
+          email: '',
+          cash_amount: 100,
+          incomes: [
+            {
+              id: 'i1',
+              name: 'Salary',
+              amount: 1000,
+              frequency: 'monthly',
+              withhold_taxes: false,
+              start: 'immediately',
+              end: 'never',
+              change_over_time: 'none',
+            },
+            { id: 'i2', name: 'Broken', amount: 'NaN' },
+          ],
+        },
+        portfolios: [],
+      }),
+    )
+    appStore.load()
+
+    expect(appStore.profile.name).toBe('Jane')
+    expect(appStore.profile.cash_amount).toBe(100)
+    expect(appStore.profile.incomes?.map((i) => i.id)).toEqual(['i1'])
+  })
+
+  it('drops only the invalid transfer inside an otherwise valid portfolio', () => {
+    backing.set(
+      storageKeys.DATA,
+      JSON.stringify({
+        lastUpdated: 1,
+        profile: { name: 'Jane', email: '' },
+        portfolios: [
+          {
+            ...validPortfolio,
+            transfers: [
+              {
+                id: 't1',
+                name: 'Valid',
+                from_asset_id: 'cash',
+                to_asset_id: 'inv-1',
+                amount: 100,
+                schedule: 'one_time',
+                transaction_year: 2030,
+                transaction_month: 1,
+              },
+              { id: 't2', name: 'Broken', from_asset_id: 'cash' },
+            ],
+          },
+        ],
+      }),
+    )
+    appStore.load()
+
+    expect(appStore.portfolios).toHaveLength(1)
+    expect(appStore.portfolios[0].transfers?.map((t) => t.id)).toEqual(['t1'])
+  })
+
+  it('falls back to the default profile when scalar profile fields are broken', () => {
+    backing.set(
+      storageKeys.DATA,
+      JSON.stringify({
+        lastUpdated: 1,
+        profile: { name: 42, email: [] },
+        portfolios: [validPortfolio],
+      }),
+    )
+    appStore.load()
+
+    expect(appStore.profile.name).toBe('')
+    // Valid portfolios still survive a broken profile.
+    expect(appStore.portfolios.map((p) => p.id)).toEqual(['p1'])
+  })
+
+  it('salvages nothing but still quarantines a legacy pre-rewrite payload', () => {
+    const legacy = JSON.stringify({ lastUpdated: 1, clients: [{ name: 'Old shape' }] })
+    backing.set(storageKeys.DATA, legacy)
+    appStore.load()
+
+    expect(appStore.profile.name).toBe('')
+    expect(appStore.portfolios).toEqual([])
+    expect(loadErrorStore.error?.raw).toBe(legacy)
+    expect(recoveryKeys()).toHaveLength(1)
   })
 })

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -1,10 +1,19 @@
+import { z } from 'zod'
+
 import {
   type Portfolio,
   type Profile,
   type StoredData,
+  expenseSchema,
+  incomeSchema,
+  portfolioSchema,
+  profileInvestmentSchema,
+  profileLiabilitySchema,
   profileSchema,
+  profileTangibleAssetSchema,
   repairStoredCashFlowMonths,
   storedDataSchema,
+  transferSchema,
 } from '$lib/schemas'
 import storageKeys from '$lib/storage-keys'
 import {
@@ -17,6 +26,7 @@ import {
   parseDateOnly,
 } from '$lib/utils'
 
+import { loadErrorStore } from './load-error.svelte'
 import type { PortfolioStore } from './portfolio.svelte'
 import { withPortfolioStore } from './portfolio.svelte'
 import { storageErrorStore } from './storage-error.svelte'
@@ -93,19 +103,114 @@ const DEFAULT_PROFILE: Profile = {
   email: '',
 }
 
-function loadData(): StoredData {
-  try {
-    const raw = localStorage.getItem(storageKeys.DATA)
-    if (raw) {
-      // Repair before parsing: data stored before stricter validation rules
-      // must keep loading, otherwise the whole dataset falls back to the
-      // empty default and gets overwritten on the next persist.
-      return storedDataSchema.parse(repairStoredCashFlowMonths(JSON.parse(raw)))
-    }
-  } catch (e) {
-    console.error('Failed to load data from localStorage', e)
-  }
+function defaultStoredData(): StoredData {
   return { lastUpdated: 0, profile: { ...DEFAULT_PROFILE }, portfolios: [] }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  // null check is for raw JSON.parse output, which can legitimately be null.
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+// Keep only the array elements that individually satisfy the schema.
+// Non-arrays collapse to undefined (every list is optional on the profile).
+function salvageArray<T>(value: unknown, schema: z.ZodType<T>): T[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const valid: T[] = []
+  for (const item of value) {
+    const result = schema.safeParse(item)
+    if (result.success) valid.push(result.data)
+  }
+  return valid
+}
+
+/**
+ * Best-effort recovery of a stored payload that failed full-schema parsing:
+ * drop only the records that are individually invalid instead of discarding
+ * everything. A profile whose scalar fields are broken falls back to the
+ * default profile; invalid list items and portfolios are dropped one by one.
+ * The unparseable original is quarantined separately, so nothing is lost.
+ */
+function salvageStoredData(raw: string): StoredData {
+  let parsed: unknown
+  try {
+    parsed = repairStoredCashFlowMonths(JSON.parse(raw))
+  } catch {
+    return defaultStoredData()
+  }
+  if (!isRecord(parsed)) return defaultStoredData()
+
+  let profile: Profile = { ...DEFAULT_PROFILE }
+  if (isRecord(parsed.profile)) {
+    const candidate = {
+      ...parsed.profile,
+      investments: salvageArray(parsed.profile.investments, profileInvestmentSchema),
+      tangible_assets: salvageArray(parsed.profile.tangible_assets, profileTangibleAssetSchema),
+      liabilities: salvageArray(parsed.profile.liabilities, profileLiabilitySchema),
+      incomes: salvageArray(parsed.profile.incomes, incomeSchema),
+      expenses: salvageArray(parsed.profile.expenses, expenseSchema),
+    }
+    const result = profileSchema.safeParse(candidate)
+    if (result.success) profile = result.data
+  }
+
+  const portfolios: Portfolio[] = []
+  if (Array.isArray(parsed.portfolios)) {
+    for (const entry of parsed.portfolios) {
+      // Drop invalid transfers individually before judging the portfolio.
+      const candidate = isRecord(entry)
+        ? { ...entry, transfers: salvageArray(entry.transfers, transferSchema) }
+        : entry
+      const result = portfolioSchema.safeParse(candidate)
+      if (result.success) portfolios.push(result.data)
+    }
+  }
+
+  return {
+    lastUpdated: typeof parsed.lastUpdated === 'number' ? parsed.lastUpdated : 0,
+    profile,
+    portfolios,
+  }
+}
+
+/**
+ * Copy the unparseable payload to a timestamped recovery key BEFORE anything
+ * can overwrite the main key (the first persist() after a failed load would
+ * otherwise destroy the only copy of the user's data), then surface the
+ * recovery dialog.
+ */
+function quarantineCorruptData(raw: string): void {
+  const key = `${storageKeys.DATA_CORRUPT_PREFIX}${Date.now()}`
+  let recoveryKey: string | undefined
+  try {
+    localStorage.setItem(key, raw)
+    recoveryKey = key
+  } catch (e) {
+    console.error('Failed to write the recovery copy; keeping it in memory only', e)
+  }
+  loadErrorStore.set({ raw, recoveryKey })
+}
+
+function loadData(): StoredData {
+  let raw: string | undefined
+  try {
+    raw = localStorage.getItem(storageKeys.DATA) ?? undefined
+  } catch (e) {
+    console.error('Failed to read data from localStorage', e)
+    return defaultStoredData()
+  }
+  // No stored data: a genuinely fresh install, not an error.
+  if (!raw) return defaultStoredData()
+  try {
+    // Repair before parsing: data stored before stricter validation rules
+    // must keep loading, otherwise the whole dataset falls back to the
+    // empty default and gets overwritten on the next persist.
+    return storedDataSchema.parse(repairStoredCashFlowMonths(JSON.parse(raw)))
+  } catch (e) {
+    console.error('Stored data failed to parse; quarantining the original and salvaging', e)
+    quarantineCorruptData(raw)
+    return salvageStoredData(raw)
+  }
 }
 
 function withAppStore() {

--- a/src/lib/stores/load-error.svelte.ts
+++ b/src/lib/stores/load-error.svelte.ts
@@ -1,0 +1,33 @@
+export type LoadError = {
+  /** The raw unparseable payload, kept in memory for download. */
+  raw: string
+  /**
+   * localStorage key holding the quarantined copy of `raw`, or undefined if
+   * writing the quarantine copy itself failed (e.g. quota) — the in-memory
+   * `raw` is then the only surviving copy.
+   */
+  recoveryKey: string | undefined
+}
+
+function withLoadErrorStore() {
+  let error = $state<LoadError | undefined>(undefined)
+
+  return {
+    get error() {
+      return error
+    },
+    set(newError: LoadError) {
+      error = newError
+    },
+    dismiss() {
+      error = undefined
+    },
+  }
+}
+
+/**
+ * Set when loadData() finds stored data it cannot parse. The recovery dialog
+ * in the root layout consumes it, offering a download of the original payload
+ * before the user continues with whatever could be salvaged.
+ */
+export const loadErrorStore = withLoadErrorStore()

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,6 +3,7 @@
   import { locale } from 'svelte-i18n'
 
   import StorageErrorBanner from '$lib/components/storage-error-banner.svelte'
+  import StorageRecoveryDialog from '$lib/components/storage-recovery-dialog.svelte'
   import { appStore } from '$lib/stores/app.svelte'
 
   import '../app.css'
@@ -28,3 +29,4 @@
 
 {@render children()}
 <StorageErrorBanner />
+<StorageRecoveryDialog />


### PR DESCRIPTION
loadData() swallowed parse failures and returned the empty default, so
the user saw a fresh-install state and the first persist() overwrote
the still-intact payload — irreversibly destroying the only copy of
their financial data (the single worst data-loss path for a local-first
app).

On parse failure the raw payload is now copied to a timestamped
kalkul-data-corrupt-* key before anything can overwrite the main key,
a recovery dialog offers downloading the original, and loading salvages
record-by-record instead of all-or-nothing: invalid list items,
transfers, and portfolios are dropped individually; broken scalar
profile fields fall back to the default profile. Missing data (fresh
install) is distinguished from invalid data and raises no error.

Covered by unit tests for the quarantine write, per-record salvage,
profile fallback, and the legacy pre-rewrite payload shape.

Closes #99

Closes #99

---
**Stack 10/24** — stacked on `claude/persist-validation`; this PR's diff shows only its own commit. Merge the stack bottom-up (squash); after each merge the next branch may need a rebase — happy to cascade those on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)