### PR TITLE
feat: add per-year FI percent and runway to the plan projection

### DIFF
--- a/src/lib/plan-projection.test.ts
+++ b/src/lib/plan-projection.test.ts
@@ -2096,4 +2096,98 @@ describe('getYearlyPlanProjection', () => {
     )
     expect(result[0].insufficientFundExpenseIds).toEqual(['exp1'])
   })
+  it('computes per-year FI percent and runway from investable wealth and outflows', () => {
+    const expenses: Expense[] = [
+      {
+        id: 'exp1',
+        name: 'Living',
+        amount: 10_000,
+        frequency: 'yearly',
+        start: 'immediately',
+        end: 'never',
+        change_over_time: 'none',
+      },
+    ]
+    const investments: ProfileInvestment[] = [{ id: 'i1', name: 'Fund', balance: 100_000, apy: 0 }]
+    const result = getYearlyPlanProjection(
+      makePlan({ include_cash: false }),
+      makeProfile({ investments, expenses }),
+    )
+    // Year 0: investable 100,000; outflows 10,000.
+    // FI % = 100,000 / (10,000 * 25) * 100 = 40; runway = 10 years.
+    expect(result[0].fiPercent).toBeCloseTo(40, 6)
+    expect(result[0].runwayYears).toBeCloseTo(10, 6)
+  })
+
+  it('subtracts standalone liabilities from investable wealth and counts their installments as outflows', () => {
+    const liabilities: ProfileLiability[] = [
+      {
+        id: 'l1',
+        name: 'Loan',
+        outstanding_balance: 20_000,
+        installment_frequency: 'yearly',
+        annual_rate: 0,
+        installment_amount: 10_000,
+        remaining_term: 2,
+      },
+    ]
+    const result = getYearlyPlanProjection(
+      makePlan(),
+      makeProfile({ cash_amount: 100_000, liabilities }),
+    )
+    // Year 0: cash 100,000 - installment 10,000 = 90,000; outstanding 10,000.
+    // investable = 90,000 - 10,000 = 80,000; outflows = 10,000 (installment).
+    expect(result[0].fiPercent).toBeCloseTo((80_000 / 250_000) * 100, 6)
+    expect(result[0].runwayYears).toBeCloseTo(8, 6)
+    // Year 2: loan paid off, no expenses left -> no outflows -> undefined.
+    expect(result[2].fiPercent).toBeUndefined()
+    expect(result[2].runwayYears).toBeUndefined()
+  })
+
+  it('leaves FI percent and runway undefined in years with zero outflows', () => {
+    const result = getYearlyPlanProjection(makePlan(), makeProfile({ cash_amount: 50_000 }))
+    for (const entry of result) {
+      expect(entry.fiPercent).toBeUndefined()
+      expect(entry.runwayYears).toBeUndefined()
+    }
+  })
+
+  it('excludes tangibles and financed-asset debt from investable wealth', () => {
+    const tangible_assets: ProfileTangibleAsset[] = [
+      {
+        id: 't1',
+        name: 'House',
+        value: 1_000_000,
+        status: 'financed',
+        outstanding_balance: 200_000,
+        installment_frequency: 'yearly',
+        annual_rate: 0,
+        installment_amount: 20_000,
+        remaining_term: 10,
+      },
+    ]
+    const expenses: Expense[] = [
+      {
+        id: 'exp1',
+        name: 'Living',
+        amount: 10_000,
+        frequency: 'yearly',
+        start: 'immediately',
+        end: 'never',
+        change_over_time: 'none',
+      },
+    ]
+    const result = getYearlyPlanProjection(
+      makePlan({ include_cash: false }),
+      makeProfile({
+        investments: [{ id: 'i1', name: 'Fund', balance: 150_000, apy: 0 }],
+        tangible_assets,
+        expenses,
+      }),
+    )
+    // investable = investments only (house + mortgage excluded); outflows =
+    // expenses 10,000 + mortgage installment 20,000 = 30,000.
+    expect(result[0].runwayYears).toBeCloseTo(150_000 / 30_000, 6)
+    expect(result[0].fiPercent).toBeCloseTo((150_000 / (30_000 * 25)) * 100, 6)
+  })
 })

--- a/src/lib/plan-projection.ts
+++ b/src/lib/plan-projection.ts
@@ -51,6 +51,14 @@ export interface YearlyProjection {
   liabilitiesByItem: YearlyProjectionItem[]
   totalIncome: number
   totalExpenses: number
+  // Progress toward financial independence in this year: investable wealth
+  // (cash + investments − standalone liabilities outstanding) as a percent of
+  // 25× this year's outflows (living expenses + loan installments).
+  // Undefined in years with zero outflows, where the ratio is meaningless.
+  fiPercent?: number
+  // Years this year's investable wealth could cover this year's outflow
+  // level. Undefined in years with zero outflows.
+  runwayYears?: number
   // IDs of transfers that were skipped this year because the source did not
   // hold enough balance to cover the move. Used by the sidebar to surface
   // unmet cash flows. Empty in healthy years.
@@ -673,6 +681,27 @@ export function getYearlyPlanProjection(plan: Portfolio, profile: Profile): Year
       ),
     }))
 
+    // 8. Per-year FI % and runway, mirroring the dashboard's snapshot
+    //    formulas (getFiPercent/getRunwayYears in financial-totals.ts):
+    //    investable wealth excludes tangibles and subtracts only standalone
+    //    liabilities (the first `liabilities.length` schedules — a mortgage
+    //    is secured by its asset), while outflows include every installment
+    //    actually paid this year. Numerator and denominator are both nominal,
+    //    so the deflator cancels and the ratio is basis-independent.
+    const standaloneOutstandingNominal = liabilitySchedules
+      .slice(0, liabilities.length)
+      .reduce<Decimal>((sum, s) => sum.plus(s.outstandingByYear.get(year) ?? DECIMAL_0), DECIMAL_0)
+    const outflowsNominal = expensesThisYearNominal.plus(liabilitiesPaidThisYearNominal)
+    const investableNominal = cashNominal
+      .plus(investmentsNominal)
+      .minus(standaloneOutstandingNominal)
+    let fiPercent: number | undefined
+    let runwayYears: number | undefined
+    if (outflowsNominal.greaterThan(0)) {
+      fiPercent = Math.max(0, investableNominal.div(outflowsNominal.mul(25)).mul(100).toNumber())
+      runwayYears = Math.max(0, investableNominal.div(outflowsNominal).toNumber())
+    }
+
     projection.push({
       year,
       cash: clampNonNeg(cashReal),
@@ -685,6 +714,8 @@ export function getYearlyPlanProjection(plan: Portfolio, profile: Profile): Year
       liabilitiesByItem,
       totalIncome: incomesThisYearReal.toNumber(),
       totalExpenses: expensesThisYearReal.toNumber(),
+      fiPercent,
+      runwayYears,
       insufficientFundTransferIds: insufficientFundTransferIdsThisYear,
       insufficientFundExpenseIds: insufficientFundExpenseIdsThisYear,
     })


### PR DESCRIPTION
The dashboard's headline FI % and runway are a snapshot of today, but
both numbers evolve over the plan: loans end, expenses inflate,
balances compound. Each YearlyProjection entry now carries fiPercent
and runwayYears computed inside the yearly loop from values it already
tracks — investable wealth (cash + investments − standalone liability
outstanding) against the year's outflows (living expenses + every
installment actually paid). Zero-outflow years yield undefined, the
same guard as the dashboard formulas. Numerator and denominator are
both nominal, so the deflator cancels.

Closes #165



Closes #165

Note: touches the same file as #203 and the accumulator PR — recommended merge order: #203, this, accumulator (later ones may need a trivial rebase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
