### PR TITLE
fix: parse number input locale-aware so '1,234' stops becoming 1.234

### DIFF
--- a/src/lib/components/suffixed-input.svelte
+++ b/src/lib/components/suffixed-input.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Input } from '$lib/components/ui/input'
+  import { decimalSeparatorOf, formatNumberInput, parseNumberInput } from '$lib/parse-number-input'
   import { cn } from '$lib/utils'
 
   interface Props {
@@ -29,34 +30,20 @@
   // Digits, minus, and both decimal separators.
   const TYPING_RE = /[^0-9.,-]/g
 
-  function parseDraft(raw: string): number | undefined {
-    if (!raw) return undefined
-    // Normalize separators: strip thousand separators, allow either . or , as decimal.
-    // Heuristic: the last '.' or ',' is the decimal separator; earlier ones are group separators.
-    const trimmed = raw.trim().replace(/\s/g, '')
-    const lastDot = trimmed.lastIndexOf('.')
-    const lastComma = trimmed.lastIndexOf(',')
-    const lastSep = Math.max(lastDot, lastComma)
-    let normalized: string
-    if (lastSep === -1) {
-      normalized = trimmed
-    } else {
-      const intPart = trimmed.slice(0, lastSep).replace(/[.,\s]/g, '')
-      const fracPart = trimmed.slice(lastSep + 1)
-      normalized = `${intPart}.${fracPart}`
-    }
-    const n = Number(normalized)
-    return Number.isFinite(n) ? n : undefined
-  }
+  // The formatter the unfocused field displays with — parsing derives its
+  // decimal separator from the same function, so whatever the field shows
+  // always parses back to the same value.
+  const effectiveFormat = $derived(
+    formatNumber ?? ((n: number) => n.toLocaleString(undefined, { maximumFractionDigits: 4 })),
+  )
+  const decimalSep = $derived(decimalSeparatorOf(effectiveFormat))
 
-  function formatDisplay(n: number | undefined): string {
-    if (n === undefined || !Number.isFinite(n)) return ''
-    if (formatNumber) return formatNumber(n)
-    return n.toLocaleString(undefined, { maximumFractionDigits: 4 })
+  function parseDraft(raw: string): number | undefined {
+    return parseNumberInput(raw, decimalSep)
   }
 
   // What the input should show given focus state.
-  let displayValue = $derived(focused ? draft : formatDisplay(value))
+  let displayValue = $derived(focused ? draft : formatNumberInput(value, effectiveFormat))
 
   function handleFocus() {
     focused = true

--- a/src/lib/parse-number-input.test.ts
+++ b/src/lib/parse-number-input.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+
+import { decimalSeparatorOf, formatNumberInput, parseNumberInput } from './parse-number-input'
+import { formatNumber } from './utils'
+
+const enFormat = (n: number) => formatNumber(n, 'en')
+const csFormat = (n: number) => formatNumber(n, 'cs-CZ')
+
+describe('decimalSeparatorOf', () => {
+  it('derives the separator from the formatter', () => {
+    expect(decimalSeparatorOf(enFormat)).toBe('.')
+    expect(decimalSeparatorOf(csFormat)).toBe(',')
+  })
+})
+
+describe('parseNumberInput (en: "." decimal, "," grouping)', () => {
+  const parse = (raw: string) => parseNumberInput(raw, '.')
+
+  it('parses plain integers and decimals', () => {
+    expect(parse('1234')).toBe(1234)
+    expect(parse('1234.56')).toBe(1234.56)
+    expect(parse('-42')).toBe(-42)
+    expect(parse('0.5')).toBe(0.5)
+  })
+
+  it('round-trips the formatter output with thousands separators', () => {
+    // The unfocused field displays exactly this for 1234 — pasting or
+    // retyping it must not become 1.234.
+    expect(parse('1,234')).toBe(1234)
+    expect(parse('1,234,567')).toBe(1234567)
+    expect(parse(enFormat(1234567.89))).toBe(1234567.89)
+  })
+
+  it('strips spaces used as group separators', () => {
+    expect(parse('1 234')).toBe(1234)
+    expect(parse('1 234 567')).toBe(1234567)
+  })
+
+  it('treats a comma outside grouping position as a decimal', () => {
+    expect(parse('1,5')).toBe(1.5)
+    expect(parse('0,5')).toBe(0.5)
+    expect(parse('12,34')).toBe(12.34)
+  })
+
+  it('uses the last separator as decimal when both kinds are present', () => {
+    expect(parse('1.234,56')).toBe(1234.56)
+    expect(parse('1,234.56')).toBe(1234.56)
+    expect(parse('1.234.567,8')).toBe(1234567.8)
+  })
+
+  it('returns undefined for empty or unparseable drafts', () => {
+    expect(parse('')).toBeUndefined()
+    expect(parse('-')).toBeUndefined()
+    expect(parse('..')).toBeUndefined()
+    expect(parse('abc')).toBeUndefined()
+  })
+
+  it('salvages a messy mixed draft by honoring the last separator', () => {
+    // Mid-typing noise: better to keep tracking a plausible value than to
+    // clear the field.
+    expect(parse('1.2.3,4')).toBe(123.4)
+  })
+})
+
+describe('parseNumberInput (cs: "," decimal, spaces grouping)', () => {
+  const parse = (raw: string) => parseNumberInput(raw, ',')
+
+  it('keeps Czech decimal entry working', () => {
+    // A cs-locale comma is always a decimal separator, even in what an
+    // en-locale would read as grouping position.
+    expect(parse('1,234')).toBe(1.234)
+    expect(parse('1,5')).toBe(1.5)
+  })
+
+  it('round-trips the cs formatter output', () => {
+    expect(parse(csFormat(1234567.89))).toBe(1234567.89)
+    expect(parse('1 234 567')).toBe(1234567)
+  })
+
+  it('treats a repeated comma as grouping, not a decimal', () => {
+    expect(parse('1,234,567')).toBe(1234567)
+  })
+
+  it('treats a dot as grouping in grouping position and decimal otherwise', () => {
+    expect(parse('1.234')).toBe(1234)
+    expect(parse('1.5')).toBe(1.5)
+  })
+
+  it('uses the last separator as decimal when both kinds are present', () => {
+    expect(parse('1.234,56')).toBe(1234.56)
+    expect(parse('1,234.56')).toBe(1234.56)
+  })
+})
+
+describe('formatNumberInput', () => {
+  it('formats through the provided formatter', () => {
+    expect(formatNumberInput(1234.56, enFormat)).toBe('1,234.56')
+    expect(formatNumberInput(undefined, enFormat)).toBe('')
+    expect(formatNumberInput(Number.NaN, enFormat)).toBe('')
+  })
+})

--- a/src/lib/parse-number-input.ts
+++ b/src/lib/parse-number-input.ts
@@ -1,0 +1,93 @@
+/**
+ * Locale-aware parsing for user-typed numbers (SuffixedInput draft values).
+ *
+ * The display side formats through appStore.formatNumber, so "1,234" is
+ * exactly what an en-locale user sees for 1234 — parsing must round-trip
+ * that, while a cs-locale user typing "1,234" means one-point-two-three-four.
+ * The old last-separator-is-decimal heuristic got both wrong ("1,234" → 1.234
+ * in every locale, "1,234,567" → 1234.567).
+ */
+
+/**
+ * Infer the decimal separator the given formatter produces by probing it with
+ * a fractional value. Deriving it from the formatter (instead of threading a
+ * locale string through component props) keeps parsing and display consistent
+ * by construction.
+ */
+export function decimalSeparatorOf(formatNumber: (n: number) => string): string {
+  const probe = formatNumber(1.1).match(/1(\D)1/)
+  return probe?.[1] ?? '.'
+}
+
+// Grouping shape: a separator followed by exactly three digits, e.g. the
+// ",234" in "1,234" or ".567" in "1.234.567".
+const THREE_DIGIT_GROUP = /^\d{3}$/
+
+/**
+ * Parse a typed draft into a number, treating `decimalSep` (from
+ * decimalSeparatorOf) as the locale's decimal separator.
+ *
+ * - whitespace (including NBSP group separators) is stripped
+ * - both '.' and ',' present: the last-typed one is the decimal separator
+ * - one separator, repeated: always grouping ("1,234,567" → 1234567)
+ * - one separator, single occurrence: the locale decimal separator parses as
+ *   decimal; the other one is grouping only when followed by exactly three
+ *   digits ("1,234" → 1234 in en), otherwise the user meant a decimal
+ *   ("0,5" → 0.5 even in en)
+ *
+ * Returns undefined for empty or unparseable drafts.
+ */
+export function parseNumberInput(raw: string, decimalSep: string): number | undefined {
+  if (!raw) return undefined
+  // Strip every kind of space (regular, NBSP, narrow NBSP) — they can only
+  // be group separators.
+  const trimmed = raw.replace(/[\s\u00A0\u202F]/g, '')
+  if (!trimmed || trimmed === '-') return undefined
+
+  const separators = [...trimmed].filter((ch) => ch === '.' || ch === ',' || ch === decimalSep)
+  const uniqueSeparators = new Set(separators)
+
+  let normalized: string
+  if (separators.length === 0) {
+    normalized = trimmed
+  } else if (uniqueSeparators.size > 1) {
+    // Mixed separators: the last one typed is the decimal separator, the
+    // rest is grouping ("1.234,56" → 1234.56, "1,234.56" → 1234.56).
+    const lastSep = separators[separators.length - 1]
+    const lastIdx = trimmed.lastIndexOf(lastSep)
+    const intPart = trimmed.slice(0, lastIdx).replace(/[^0-9-]/g, '')
+    normalized = `${intPart}.${trimmed.slice(lastIdx + 1)}`
+  } else {
+    const sep = separators[0]
+    const first = trimmed.indexOf(sep)
+    const last = trimmed.lastIndexOf(sep)
+    const afterLast = trimmed.slice(last + 1)
+    if (first !== last) {
+      // Same separator repeated can only be grouping.
+      normalized = trimmed.replaceAll(sep, '')
+    } else if (sep === decimalSep) {
+      normalized = `${trimmed.slice(0, last)}.${afterLast}`
+    } else if (THREE_DIGIT_GROUP.test(afterLast)) {
+      // Non-decimal separator in grouping position: "1,234" typed by an
+      // en-locale user is the formatter's own output for 1234.
+      normalized = trimmed.replaceAll(sep, '')
+    } else {
+      // Non-grouping shape ("0,5", "12,34"): the user meant a decimal.
+      normalized = `${trimmed.slice(0, last)}.${afterLast}`
+    }
+  }
+
+  // Number('') and Number('-') would coerce to 0 after separator stripping.
+  if (!/\d/.test(normalized)) return undefined
+  const parsed = Number(normalized)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+/** Format a value for the unfocused input; empty string when unset. */
+export function formatNumberInput(
+  value: number | undefined,
+  formatNumber: (n: number) => string,
+): string {
+  if (value === undefined || !Number.isFinite(value)) return ''
+  return formatNumber(value)
+}


### PR DESCRIPTION
SuffixedInput treated the last '.' or ',' as the decimal separator
regardless of locale, while display formatting was locale-aware — an
en-locale field showing '1,234' for 1234 parsed that same text back as
1.234, and '1,234,567' became 1234.567 in every locale. The parser had
no tests.

parseDraft/formatDisplay now live in src/lib/parse-number-input.ts. The
decimal separator is derived from the same formatNumber the field
displays with, so display output always round-trips: a lone locale
decimal separator parses as decimal, a separator in grouping position
(three trailing digits) as grouping, repeated separators always as
grouping, and mixed input honors the last-typed separator. Czech
decimal entry ('1,234' → 1.234) keeps working. Covered by a table of
hardcoded per-locale expectations, including formatter round-trips
with NBSP grouping.

Closes #111



Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)
