### PR TITLE
fix: pluralize the year suffix with ICU so Czech shows rok/roky/roku/let

### DIFF
--- a/src/lib/components/liabilities-editor.svelte
+++ b/src/lib/components/liabilities-editor.svelte
@@ -206,7 +206,9 @@
             <Label>{$_('page.setup.liabilities.remainingTerm')}</Label>
             <SuffixedInput
               value={liability.remaining_term}
-              suffix={$_('page.setup.liabilities.years')}
+              suffix={$_('page.setup.liabilities.years', {
+                values: { count: liability.remaining_term ?? 0 },
+              })}
               formatNumber={appStore.formatNumber}
               onValueChange={(v) => {
                 liability.remaining_term = v

--- a/src/lib/components/tangible-assets-editor.svelte
+++ b/src/lib/components/tangible-assets-editor.svelte
@@ -246,7 +246,9 @@
               <Label>{$_('page.setup.tangibleAssets.remainingTerm')}</Label>
               <SuffixedInput
                 value={asset.remaining_term}
-                suffix={$_('page.setup.tangibleAssets.years')}
+                suffix={$_('page.setup.tangibleAssets.years', {
+                  values: { count: asset.remaining_term ?? 0 },
+                })}
                 formatNumber={appStore.formatNumber}
                 onValueChange={(v) => {
                   asset.remaining_term = v

--- a/src/lib/locales/cs.json
+++ b/src/lib/locales/cs.json
@@ -313,7 +313,7 @@
         "annualRate": "Roční úroková sazba",
         "installmentAmount": "Výše splátky",
         "remainingTerm": "Zbývající doba",
-        "years": "let",
+        "years": "{count, plural, one {rok} few {roky} many {roku} other {let}}",
         "defaultName": "Hmotný majetek {index}"
       },
       "liabilities": {
@@ -325,7 +325,7 @@
         "annualRate": "Roční úroková sazba",
         "installmentAmount": "Výše splátky",
         "remainingTerm": "Zbývající doba",
-        "years": "let",
+        "years": "{count, plural, one {rok} few {roky} many {roku} other {let}}",
         "defaultName": "Závazek {index}"
       },
       "investments": {

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -313,7 +313,7 @@
         "annualRate": "Annual percentage rate",
         "installmentAmount": "Installment amount",
         "remainingTerm": "Remaining term",
-        "years": "years",
+        "years": "{count, plural, one {year} other {years}}",
         "defaultName": "Tangible asset {index}"
       },
       "liabilities": {
@@ -325,7 +325,7 @@
         "annualRate": "Annual percentage rate",
         "installmentAmount": "Installment amount",
         "remainingTerm": "Remaining term",
-        "years": "years",
+        "years": "{count, plural, one {year} other {years}}",
         "defaultName": "Liability {index}"
       },
       "investments": {

--- a/src/routes/(app)/plan/[id]/asset-edit-dialog.svelte
+++ b/src/routes/(app)/plan/[id]/asset-edit-dialog.svelte
@@ -653,7 +653,9 @@
               <Label>{$_('page.setup.tangibleAssets.remainingTerm')}</Label>
               <SuffixedInput
                 value={form.remaining_term}
-                suffix={$_('page.setup.tangibleAssets.years')}
+                suffix={$_('page.setup.tangibleAssets.years', {
+                  values: { count: form.remaining_term ?? 0 },
+                })}
                 formatNumber={appStore.formatNumber}
                 onValueChange={(v) => (form.remaining_term = v)}
               />
@@ -706,7 +708,9 @@
             <Label>{$_('page.setup.liabilities.remainingTerm')}</Label>
             <SuffixedInput
               value={form.remaining_term}
-              suffix={$_('page.setup.liabilities.years')}
+              suffix={$_('page.setup.liabilities.years', {
+                values: { count: form.remaining_term ?? 0 },
+              })}
               formatNumber={appStore.formatNumber}
               onValueChange={(v) => (form.remaining_term = v)}
             />


### PR DESCRIPTION
Loan-term and horizon inputs rendered a static 'let' suffix, but Czech
needs 'rok' for 1, 'roky' for 2-4 and 'let' for 5+ — a 3-year mortgage
showed the ungrammatical '3 let'. The four remaining-term suffixes now
use an ICU plural key driven by the current input value (including
'roku' for fractional terms and English one/other), verified in the
browser in both languages.

Closes #125



Closes #125

Note: small overlap with #202 in the two editors — whichever merges second needs a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
