### PR TITLE
fix: stop the setup form resetting the saved currency on Back navigation

### DIFF
--- a/src/routes/(onboarding)/profile/+page.svelte
+++ b/src/routes/(onboarding)/profile/+page.svelte
@@ -50,14 +50,16 @@
 
   let userChangedCurrency = $state(false)
 
-  $effect(() => {
-    if (location && !userChangedCurrency) {
-      const mapped = countryCurrencyMap[location]
-      if (mapped) {
-        currency = mapped
-      }
-    }
-  })
+  // Map country -> currency only when the user actually changes the country.
+  // The previous $effect also ran on mount, where userChangedCurrency is
+  // always freshly false — so navigating Back to this page overwrote the
+  // saved currency with the country default (issue #38: "currency reverts
+  // back to HUF").
+  function handleLocationChange(value: string) {
+    if (userChangedCurrency) return
+    const mapped = countryCurrencyMap[value]
+    if (mapped) currency = mapped
+  }
 
   let canContinue = $derived(name.trim().length > 0 && birthYear !== '' && birthMonth !== '')
 
@@ -121,6 +123,7 @@
           bind:value={location}
           items={countries}
           placeholder={$_('page.setup.aboutYou.selectCountry')}
+          onValueChange={handleLocationChange}
         />
       </div>
       <div class="flex w-32 flex-col gap-2">


### PR DESCRIPTION
The About-you page mapped country -> currency inside an $effect guarded
by a userChangedCurrency flag — but the flag is freshly false on every
mount, so merely returning to the page (e.g. clicking Back from the
next step) re-ran the mapping and overwrote the user's saved currency
with the country default ('Currency reverts back to HUF' in #38). The
mapping now runs in the location select's onValueChange, i.e. only when
the user actually changes the country.

The other symptoms reported in #38 (birth month drifting one earlier
per cycle, birthdate changing) were caused by UTC parsing/encoding of
date-only strings and were fixed by the parseDateOnly/toDateOnlyString
helpers; verified stable across repeated Continue/Back cycles.

Closes #38



Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)
